### PR TITLE
Only convert back to input type for Float16 and Float32 in the quantile function for the normal distribution.

### DIFF
--- a/src/basicfuns.jl
+++ b/src/basicfuns.jl
@@ -1,7 +1,5 @@
 # common facilities
 
-f64(x::Real) = convert(Float64, x)
-
 # scalar functions
 
 xlogx(x::Real) = x > zero(x) ? x * log(x) : zero(log(x))

--- a/src/distrs/beta.jl
+++ b/src/distrs/beta.jl
@@ -13,4 +13,4 @@ import .RFunctions:
 
 # pdf
 betapdf(α::Float64, β::Float64, x::Float64) = exp(betalogpdf(α, β, x))
-betapdf(α::Real, β::Real, x::Real) = betapdf(f64(α), f64(β), f64(x))
+betapdf(α::Real, β::Real, x::Real) = betapdf(Float64(α), Float64(β), Float64(x))

--- a/src/distrs/norm.jl
+++ b/src/distrs/norm.jl
@@ -31,20 +31,20 @@ normlogccdf(z::Number) = z > 1.0 ?
     log1p(-erfc(-z * invsqrt2)/2)
 normlogccdf(μ::Real, σ::Real, x::Number) = normlogccdf(zval(μ, σ, x))
 
-# invcdf. Fixme! Support more precisions than Float64
-norminvcdf(p::Real) = convert(typeof(p), _norminvcdf_impl(f64(p)))
+norminvcdf(p::Real) = -erfcinv(2*p) * sqrt2
 norminvcdf(μ::Real, σ::Real, p::Real) = xval(μ, σ, norminvcdf(p))
 
-# invccdf. Fixme! Support more precisions than Float64
-norminvccdf(p::Real) = convert(typeof(p), -_norminvcdf_impl(f64(p)))
+norminvccdf(p::Real) = erfcinv(2*p) * sqrt2
 norminvccdf(μ::Real, σ::Real, p::Real) = xval(μ, σ, norminvccdf(p))
 
 # invlogcdf. Fixme! Support more precisions than Float64
-norminvlogcdf(lp::Real) = convert(typeof(lp), _norminvlogcdf_impl(f64(lp)))
+norminvlogcdf(lp::Union{Float16,Float32}) = convert(typeof(lp), _norminvlogcdf_impl(Float64(lp)))
+norminvlogcdf(lp::Real) = _norminvlogcdf_impl(Float64(lp))
 norminvlogcdf(μ::Real, σ::Real, lp::Real) = xval(μ, σ, norminvlogcdf(lp))
 
 # invlogccdf. Fixme! Support more precisions than Float64
-norminvlogccdf(lp::Real) = convert(typeof(lp), -_norminvlogcdf_impl(f64(lp)))
+norminvlogccdf(lp::Union{Float16,Float32}) = convert(typeof(lp), -_norminvlogcdf_impl(Float64(lp)))
+norminvlogccdf(lp::Real) = -_norminvlogcdf_impl(Float64(lp))
 norminvlogccdf(μ::Real, σ::Real, lp::Real) = xval(μ, σ, norminvlogccdf(lp))
 
 
@@ -55,23 +55,6 @@ norminvlogccdf(μ::Real, σ::Real, lp::Real) = xval(μ, σ, norminvlogccdf(lp))
 #   Wichura, M.J. (1988) Algorithm AS 241: The Percentage Points of the Normal Distribution
 #   Journal of the Royal Statistical Society. Series C (Applied Statistics), Vol. 37, No. 3, pp. 477-484
 #
-function _norminvcdf_impl(p::Float64)
-    if 0.0 < p < 1.0
-        q = p - 0.5
-        if abs(q) <= 0.425
-            _qnorm_ker1(q)
-        else
-            r = sqrt(q < 0 ? -log(p) : -log1p(-p))
-            copysign(_qnorm_ker2(r), q)
-        end
-    else
-        if p <= 0.0
-            p == 0.0 ? -Inf : NaN
-        else # p >= 1.0
-            p == 1.0 ? Inf : NaN
-        end
-    end
-end
 
 function _norminvlogcdf_impl(lp::Float64)
     if isfinite(lp) && lp < 0.0

--- a/test/rmath.jl
+++ b/test/rmath.jl
@@ -27,7 +27,7 @@ end
 get_statsfun(fname) = eval(Symbol(fname))
 get_rmathfun(fname) = eval(parse(string("RFunctions.", fname)))
 
-function rmathcomp(basename, params, X::AbstractArray, rtol=1.0e-12)
+function rmathcomp(basename, params, X::AbstractArray, rtol=100eps(float(one(eltype(X)))))
     pdf     = string(basename, "pdf")
     logpdf  = string(basename, "logpdf")
     cdf     = string(basename, "cdf")
@@ -185,6 +185,8 @@ rmathcomp_tests("norm", [
     ((0.0, 1.0), -6.0:0.01:6.0),
     ((2.0, 1.0), -3.0:0.01:7.0),
     ((0.0, 0.5), -3.0:0.01:3.0),
+    ((0, 1), -3:3),
+    ((0, 1), -Float16(3):Float16(0.01):Float16(3))
 ])
 
 rmathcomp_tests("ntdist", [


### PR DESCRIPTION
Use erfcinv to compute the quantiles of the normal distribution.

Fixes https://github.com/JuliaStats/Distributions.jl/issues/516