### PR TITLE
Fix depwarn on 0.6 due to vectorized functions

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,3 @@
 julia 0.4
-Compat 0.8.4
+Compat 0.9.1
 Rmath 0.1.0

--- a/src/StatsFuns.jl
+++ b/src/StatsFuns.jl
@@ -3,6 +3,7 @@ VERSION >= v"0.4.0-dev+6521" && __precompile__(true)
 module StatsFuns
 
 import Base: Math.@horner, @irrational
+using Compat
 
 export
     # constants

--- a/src/basicfuns.jl
+++ b/src/basicfuns.jl
@@ -43,15 +43,15 @@ log2mexp(x::Real) = log1p(-expm1(x))
 logexpm1(x::Real) = x <= 18.0 ? log(expm1(x)) : x <= 33.3 ? x - exp(-x) : oftype(exp(-x), x)
 logexpm1(x::Float32) = x <= 9f0 ? log(expm1(x)) : x <= 16f0 ? x - exp(-x) : oftype(exp(-x), x)
 
-@vectorize_1arg Real xlogx
-@vectorize_2arg Real xlogy
-@vectorize_1arg Real logistic
-@vectorize_1arg Real logit
-@vectorize_1arg Real log1psq
-@vectorize_1arg Real log1pexp
-@vectorize_1arg Real log1mexp
-@vectorize_1arg Real log2mexp
-@vectorize_1arg Real logexpm1
+Compat.@dep_vectorize_1arg Real xlogx
+Compat.@dep_vectorize_2arg Real xlogy
+Compat.@dep_vectorize_1arg Real logistic
+Compat.@dep_vectorize_1arg Real logit
+Compat.@dep_vectorize_1arg Real log1psq
+Compat.@dep_vectorize_1arg Real log1pexp
+Compat.@dep_vectorize_1arg Real log1mexp
+Compat.@dep_vectorize_1arg Real log2mexp
+Compat.@dep_vectorize_1arg Real logexpm1
 
 const softplus = log1pexp
 const invsoftplus = logexpm1

--- a/test/basicfuns.jl
+++ b/test/basicfuns.jl
@@ -1,5 +1,6 @@
 using StatsFuns
 using Base.Test
+using Compat
 
 # xlogx & xlogy
 
@@ -81,7 +82,7 @@ println("\ttesting logsumexp ...")
 println("\ttesting softmax ...")
 
 x = [1.0, 2.0, 3.0]
-r = exp(x) ./ sum(exp(x))
+r = @compat exp.(x) ./ sum(exp.(x))
 @test_approx_eq softmax([1.0, 2.0, 3.0]) r
 softmax!(x)
 @test_approx_eq x r


### PR DESCRIPTION
Requires https://github.com/JuliaLang/Compat.jl/pull/280 and a new `Compat` tag.