### PR TITLE
Added handling of Infs and NaNs to logsumexp, with tests.

### DIFF
--- a/src/basicfuns.jl
+++ b/src/basicfuns.jl
@@ -129,8 +129,8 @@ logsumexp(x::Real, y::Real) = logsumexp(promote(x, y)...)
 function logsumexp{T<:Real}(x::AbstractArray{T})
     isempty(x) && return -T(Inf)
     u = maximum(x)
-    abs(u) == Inf && return any(isnan.(x)) ? T(NaN) : u
-    s = zero(T)
+    abs(u) == Inf && return any(isnan(x)) ? T(NaN) : u
+    s = zero(Base.promote_op(exp, T))
     for i = 1:length(x)
         @inbounds s += exp(x[i] - u)
     end

--- a/src/basicfuns.jl
+++ b/src/basicfuns.jl
@@ -119,13 +119,18 @@ end
 
 ## logsumexp
 
-logsumexp{T<:Real}(x::T, y::T) = x > y ? x + log1p(exp(y - x)) : y + log1p(exp(x - y))
+function logsumexp{T<:Real}(x::T, y::T)
+    x == y && abs(x) == Inf && return x
+    x > y ? x + log1p(exp(y - x)) : y + log1p(exp(x - y))
+end
+
 logsumexp(x::Real, y::Real) = logsumexp(promote(x, y)...)
 
 function logsumexp{T<:Real}(x::AbstractArray{T})
-    isempty(x) && return -Inf
+    isempty(x) && return -T(Inf)
     u = maximum(x)
-    s = 0.
+    abs(u) == Inf && return any(isnan.(x)) ? T(NaN) : u
+    s = zero(T)
     for i = 1:length(x)
         @inbounds s += exp(x[i] - u)
     end

--- a/src/basicfuns.jl
+++ b/src/basicfuns.jl
@@ -127,10 +127,11 @@ end
 logsumexp(x::Real, y::Real) = logsumexp(promote(x, y)...)
 
 function logsumexp{T<:Real}(x::AbstractArray{T})
-    isempty(x) && return -T(Inf)
+    S = typeof(exp(zero(T)))    # because of 0.4.0
+    isempty(x) && return -S(Inf)
     u = maximum(x)
-    abs(u) == Inf && return any(isnan(x)) ? T(NaN) : u
-    s = zero(Base.promote_op(exp, T))
+    abs(u) == Inf && return any(isnan, x) ? S(NaN) : u
+    s = zero(S)
     for i = 1:length(x)
         @inbounds s += exp(x[i] - u)
     end

--- a/test/basicfuns.jl
+++ b/test/basicfuns.jl
@@ -76,14 +76,16 @@ println("\ttesting logsumexp ...")
 @test_approx_eq logsumexp([1.0, 2.0, 3.0]) 3.40760596444438
 @test_approx_eq logsumexp([1.0, 2.0, 3.0] .+ 1000.) 1003.40760596444438
 
-let cases = [([-Inf, -Inf], -Inf),
-             ([-Inf, -Inf32], -Inf),
+let cases = [([-Inf, -Inf], -Inf),   # correct handling of all -Inf
+             ([-Inf, -Inf32], -Inf), # promotion
+             ([-Inf32, -Inf32], -Inf32), # Float32
              ([-Inf, Inf], Inf),
              ([-Inf, 9.0], 9.0),
              ([Inf, 9.0], Inf),
-             ([NaN, 9.0], NaN),
-             ([NaN, Inf], NaN),
-             ([NaN, -Inf], NaN)]
+             ([NaN, 9.0], NaN),  # NaN propagation
+             ([NaN, Inf], NaN),  # NaN propagation
+             ([NaN, -Inf], NaN), # NaN propagation
+             ([0, 0], log(2.0))] # non-float arguments
     for (arguments, result) in cases
         @test logsumexp(arguments) ≡ result
         @test logsumexp(arguments...) ≡ result

--- a/test/basicfuns.jl
+++ b/test/basicfuns.jl
@@ -76,6 +76,20 @@ println("\ttesting logsumexp ...")
 @test_approx_eq logsumexp([1.0, 2.0, 3.0]) 3.40760596444438
 @test_approx_eq logsumexp([1.0, 2.0, 3.0] .+ 1000.) 1003.40760596444438
 
+let cases = [([-Inf, -Inf], -Inf),
+             ([-Inf, -Inf32], -Inf),
+             ([-Inf, Inf], Inf),
+             ([-Inf, 9.0], 9.0),
+             ([Inf, 9.0], Inf),
+             ([NaN, 9.0], NaN),
+             ([NaN, Inf], NaN),
+             ([NaN, -Inf], NaN)]
+    for (arguments, result) in cases
+        @test logsumexp(arguments) ≡ result
+        @test logsumexp(arguments...) ≡ result
+    end
+end
+
 # softmax
 
 println("\ttesting softmax ...")


### PR DESCRIPTION
This version avoids the `Inf-Inf` errors which (incorrectly) resulted in
`NaN`s before, and also takes care to pass through actual `NaN`s.

New tests for both vector and bivariate forms.

Fixes #22.