### PR TITLE
Double backslashes in math expressions

### DIFF
--- a/src/basicfuns.jl
+++ b/src/basicfuns.jl
@@ -26,7 +26,7 @@ xlogy(x::Real, y::Real) = xlogy(promote(x, y)...)
 
 The [logistic](https://en.wikipedia.org/wiki/Logistic_function) sigmoid function mapping a real number to a value in the interval [0,1],
 ```math
-\sigma(x) = \frac{1}{e^{-x} + 1} = \frac{e^x}{1+e^x}.
+\\sigma(x) = \\frac{1}{e^{-x} + 1} = \\frac{e^x}{1+e^x}.
 ```
 
 Its inverse is the [`logit`](@ref) function.
@@ -38,7 +38,7 @@ logistic(x::Real) = inv(exp(-x) + one(x))
 
 The [logit](https://en.wikipedia.org/wiki/Logit) or log-odds transformation,
 ```math
-\log\left(\frac{x}{1-x}\right), \text{where} 0 < x < 1
+\\log\\left(\\frac{x}{1-x}\\right), \\text{where} 0 < x < 1
 ```
 Its inverse is the [`logistic`](@ref) function.
 """

--- a/src/misc.jl
+++ b/src/misc.jl
@@ -22,7 +22,7 @@ The remainder term after
 to [`lgamma`](@ref):
 
 ```math
-\log \Gamma(x) \approx x \log(x) - x + \log(2π/x)/2 = \log(x)*(x-1/2) + \log(2\pi)/2 - x
+\\log \\Gamma(x) \\approx x \\log(x) - x + \\log(2\\pi/x)/2 = \\log(x)*(x-1/2) + \\log(2\\pi)/2 - x
 ```
 
 In Julia syntax, this means:
@@ -33,7 +33,7 @@ For sufficiently large `x`, this can be approximated using the asymptotic
 _Stirling's series_ ([DLMF 5.11.1](https://dlmf.nist.gov/5.11.1)):
 
 ```math
-\frac{1}{12x} - \frac{1}{360x^3} + \frac{1}{1260x^5} - \frac{1}{1680x^7} + \ldots
+\\frac{1}{12x} - \\frac{1}{360x^3} + \\frac{1}{1260x^5} - \\frac{1}{1680x^7} + \\ldots
 ```
 
 The truncation error is bounded by the first omitted term, and is of the same sign.


### PR DESCRIPTION
Need to double the backslashes in math expressions.  Julia v0.6 is okay with the single backslashes but v0.7.0-DEV complains about unknown escape sequences.