### PR TITLE
Fallbacks for betapdf should respect support of input

### DIFF
--- a/src/distrs/beta.jl
+++ b/src/distrs/beta.jl
@@ -13,7 +13,18 @@ import .RFunctions:
     betainvlogccdf
 
 # pdf for numbers with generic types
-betapdf(α::Real, β::Real, x::Number) = x^(α - 1) * (1 - x)^(β - 1) / beta(α, β)
-
+function betapdf(α::T, β::T, x::V) where {T <: Real, V <: Number}
+    if 0 <= x <= 1
+       x^(α - 1) * (1 - x)^(β - 1) / beta(α, β) 
+    else
+       zero(T)
+    end
+end
 # logpdf for numbers with generic types
-betalogpdf(α::Real, β::Real, x::Number) = (α - 1) * log(x) + (β - 1) * log1p(-x) - lbeta(α, β)
+function betalogpdf(α::T, β::T, x::V) where {T <: Real, V <: Number}
+    if 0 <= x <= 1
+        (α - 1) * log(x) + (β - 1) * log1p(-x) - lbeta(α, β)
+    else
+       convert(T, -Inf)
+    end
+end


### PR DESCRIPTION
Ran into this issue where behavior of fallback betapdf doesn't match that from Rmath

```julia
Main> T = ForwardDiff.Dual{nothing,Float64,9}
ForwardDiff.Dual{nothing,Float64,9}

Main> a = ForwardDiff.Dual{nothing}(6.4939207766474265,0.8357436393299081,1.3579354055156831,-1.3555982865121416,1.160498244824507,-2.079327009825812,0.004863844970181275,-0.25727952518133534,-2.2389294116926743,-10.5166484082746)
Dual{nothing}(6.4939207766474265,0.8357436393299081,1.3579354055156831,-1.3555982865121416,1.160498244824507,-2.079327009825812,0.004863844970181275,-0.25727952518133534,-2.2389294116926743,-10.5166484082746)

Main> b = ForwardDiff.Dual{nothing}(232.02099155052173,323.55948699129425,490.7620357655114,-690.2228324218437,441.6711726841804,-1149.8624174807328,-1831.3399060164832,-9.586679718153569,-608.3911976640888,-2973.826015588245)
Dual{nothing}(232.02099155052173,323.55948699129425,490.7620357655114,-690.2228324218437,441.6711726841804,-1149.8624174807328,-1831.3399060164832,-9.586679718153569,-608.3911976640888,-2973.826015588245)

Main>

Main> logpdf(Beta(a.value,b.value), -1.2)
-Inf

Main> logpdf(Beta{T}(a,b), T(-1.2))
ERROR: DomainError:
log will only return a complex result if called with a complex argument. Try log(complex(x)).
Stacktrace:
 [1] nan_dom_err at .\math.jl:300 [inlined]
 [2] log at .\math.jl:419 [inlined]
 [3] log at C:\Users\deonovib\.julia\v0.6\ForwardDiff\src\dual.jl:167 [inlined]
 [4] betalogpdf(::ForwardDiff.Dual{nothing,Float64,9}, ::ForwardDiff.Dual{nothing,Float64,9}, ::ForwardDiff.Dual{nothing,Float64,9}) at C:\Users\deonovib\.julia\v0.6\StatsFuns\src\distrs\beta.jl:19
 [5] logpdf(::Distributions.Beta{ForwardDiff.Dual{nothing,Float64,9}}, ::ForwardDiff.Dual{nothing,Float64,9}) at C:\Users\deonovib\.julia\v0.6\Distributions\src\univariates.jl:540
 [6] eval(::Module, ::Any) at .\boot.jl:235

```