### PR TITLE
Write logsumexp in a more generic form

### DIFF
--- a/src/StatsFuns.jl
+++ b/src/StatsFuns.jl
@@ -44,7 +44,8 @@ export
     invsoftplus,    # alias of logexpm1
     log1pmx,        # log(1 + x) - x
     logmxp1,        # log(x) - x + 1
-    logsumexp,      # log(exp(x) + exp(y)) or log(sum(exp(x)))
+    logaddexp,      # log(exp(x) + exp(y))
+    logsumexp,      # log(sum(exp(x)))
     softmax,        # exp(x_i) / sum(exp(x)), for i
     softmax!,       # inplace softmax
 

--- a/test/basicfuns.jl
+++ b/test/basicfuns.jl
@@ -59,10 +59,11 @@ end
 end
 
 @testset "logsumexp" begin
-    @test logsumexp(2.0, 3.0)     ≈ log(exp(2.0) + exp(3.0))
-    @test logsumexp(10002, 10003) ≈ 10000 + logsumexp(2.0, 3.0)
+    @test logaddexp(2.0, 3.0)     ≈ log(exp(2.0) + exp(3.0))
+    @test logaddexp(10002, 10003) ≈ 10000 + logaddexp(2.0, 3.0)
 
     @test logsumexp([1.0, 2.0, 3.0])          ≈ 3.40760596444438
+    @test logsumexp((1.0, 2.0, 3.0))          ≈ 3.40760596444438
     @test logsumexp([1.0, 2.0, 3.0] .+ 1000.) ≈ 1003.40760596444438
 
     let cases = [([-Inf, -Inf], -Inf),   # correct handling of all -Inf
@@ -76,8 +77,8 @@ end
                  ([NaN, -Inf], NaN), # NaN propagation
                  ([0, 0], log(2.0))] # non-float arguments
         for (arguments, result) in cases
+            @test logaddexp(arguments...) ≡ result
             @test logsumexp(arguments) ≡ result
-            @test logsumexp(arguments...) ≡ result
         end
     end
 end


### PR DESCRIPTION
This uses Julia's reduction functionality to improve the `logsumexp`
functionality. It no longer relies on 1-based indexing, is fast
on CuArrays, and there is now a generic fallback for iterable collections.

I've also renamed the 2-arg `logsumexp` to `logaddexp`, since Julia
convention is to use different functions for reductions and
reducers (e.g. `max` vs `maximum`).