### PR TITLE
Proposal: generalise `logsumexp` slightly.

### DIFF
--- a/src/basicfuns.jl
+++ b/src/basicfuns.jl
@@ -190,7 +190,13 @@ function logsumexp(X)
     isempty(X) && return log(sum(X))
     reduce(logaddexp, X)
 end
-function logsumexp(X::AbstractArray{T}) where {T<:Real}
+function logsumexp(X::AbstractArray{T}; dims=nothing) where {T<:Real}
+    dims isa Nothing && return _logsumexp(X)
+    isempty(X) && return log(zero(T))
+    u = maximum(X; dims=dims)
+    return log.(sum(exp.(X .- u); dims=dims)) .+ u
+end
+function _logsumexp(X::AbstractArray{T}) where {T<:Real}
     isempty(X) && return log(zero(T))
     u = maximum(X)
     isfinite(u) || return float(u)
@@ -198,7 +204,6 @@ function logsumexp(X::AbstractArray{T}) where {T<:Real}
         u + log(sum(x -> exp(x-u), X))
     end
 end
-
 
 """
     softmax!(r::AbstractArray, x::AbstractArray)

--- a/test/basicfuns.jl
+++ b/test/basicfuns.jl
@@ -89,6 +89,9 @@ end
             @test logsumexp(arguments) ≡ result
         end
     end
+
+    x = randn(5, 1)
+    @test logsumexp(x) == logsumexp(x; dims=1)[1]
 end
 
 @testset "softmax" begin


### PR DESCRIPTION
Will add thorough testing if this is deemed something that's reasonable to include. Provides functionality similar to that found in `sum` and `maximum` etc to provide a `dims` argument which acts in the same way as `sum` and `maximum`.

e.g.
```julia
B = randn(5, 4)
A = logsumexp(B; dims=1)
```
returns a `1 x 4` matrix `A`, where `A[1, k] = logsumexp(B[:, k])`.