### PR TITLE
Fix deprecation warning

### DIFF
--- a/src/misc.jl
+++ b/src/misc.jl
@@ -53,7 +53,7 @@ which is < 1/2 ulp for x >= 10.0, and total numeric error appears to be < 2 ulps
 """
 function lstirling_asym end
 
-lstirling_asym(x::BigFloat) = lgamma(x) + x - log(x)*(x - big(0.5)) - log2π/big(2)
+lstirling_asym(x::BigFloat) = (logabsgamma(x))[1] + x - log(x)*(x - big(0.5)) - log2π/big(2)
 
 lstirling_asym(x::Integer) = lstirling_asym(float(x))
 

--- a/src/misc.jl
+++ b/src/misc.jl
@@ -53,7 +53,7 @@ which is < 1/2 ulp for x >= 10.0, and total numeric error appears to be < 2 ulps
 """
 function lstirling_asym end
 
-lstirling_asym(x::BigFloat) = (logabsgamma(x))[1] + x - log(x)*(x - big(0.5)) - log2π/big(2)
+lstirling_asym(x::BigFloat) = logabsgamma(x)[1] + x - log(x)*(x - big(0.5)) - log2π/big(2)
 
 lstirling_asym(x::Integer) = lstirling_asym(float(x))
 


### PR DESCRIPTION
From report on Slack
```
┌ Warning: `lgamma(x::Real)` is deprecated, use `(logabsgamma(x))[1]` instead.
│   caller = lstirling_asym(::BigFloat) at misc.jl:56
└ @ StatsFuns ~/.julia/packages/StatsFuns/2QE7p/src/misc.jl:56
```