### PR TITLE
Improve accuracy of logistic

### DIFF
--- a/test/basicfuns.jl
+++ b/test/basicfuns.jl
@@ -10,6 +10,10 @@ end
 
 @testset "logistic & logit" begin
     @test logistic(2)        ≈ 1.0 / (1.0 + exp(-2.0))
+    @test logistic(-750.0) === 0.0
+    @test logistic(-740.0) > 0.0
+    @test logistic(+36.0) < 1.0
+    @test logistic(+750.0) === 1.0
     @test iszero(logit(0.5))
     @test logit(logistic(2)) ≈ 2.0
 end


### PR DESCRIPTION
Change the logistic function to increase accuracy for subnormal values (e.g. `logistic(-740.0)`). See [my notes](https://github.com/johnmyleswhite/StatsFunctionsNotes/blob/master/A%20Numerically%20Accurate%20Inverse%20Logit%20Function%20for%2064-Bit%20Floating%20Point.ipynb) for extended details.