### PR TITLE
Add onepass algorithm for logsumexp

### DIFF
--- a/src/basicfuns.jl
+++ b/src/basicfuns.jl
@@ -227,11 +227,27 @@ logsubexp(x::Real, y::Real) = max(x, y) + log1mexp(-abs(x - y))
 Compute `log(sum(exp, X))` in a numerically stable way that avoids intermediate over- and
 underflow.
 
-`X` should be an iterator of real numbers.
+`X` should be an iterator of real numbers. The result is computed using a single pass over
+the data.
 
-See also: [`logsumexp_onepass`](@ref)
+# References
+
+[Sebastian Nowozin: Streaming Log-sum-exp Computation.](http://www.nowozin.net/sebastian/blog/streaming-log-sum-exp-computation.html)
 """
 logsumexp(X) = logsumexp_onepass(X)
+
+"""
+    logsumexp(X::AbstractArray{<:Real}[; dims=:])
+
+Compute `log.(sum(exp.(X); dims=dims))` in a numerically stable way that avoids
+intermediate over- and underflow.
+
+If `dims = :`, then the result is computed using a single pass over the data.
+
+# References
+
+[Sebastian Nowozin: Streaming Log-sum-exp Computation.](http://www.nowozin.net/sebastian/blog/streaming-log-sum-exp-computation.html)
+"""
 logsumexp(X::AbstractArray{<:Real}; dims=:) = _logsumexp(X, dims)
 
 _logsumexp(X::AbstractArray{<:Real}, ::Colon) = logsumexp_onepass(X)
@@ -241,19 +257,6 @@ function _logsumexp(X::AbstractArray{<:Real}, dims)
     return u .+ log.(sum(exp.(X .- u); dims=dims))
 end
 
-"""
-    logsumexp_onepass(X)
-
-Compute `log(sum(exp, X))` in a numerically stable way that avoids intermediate under- and
-overflow.
-
-In contrast to [`logsumexp`](@ref) the result is computed using a single pass over the data.
-`X` should be an iterator of real numbers.
-
-# References
-
-[Sebastian Nowozin: Streaming Log-sum-exp Computation.](http://www.nowozin.net/sebastian/blog/streaming-log-sum-exp-computation.html)
-"""
 function logsumexp_onepass(X)
     # fallback for empty collections
     isempty(X) && return log(sum(X))

--- a/src/basicfuns.jl
+++ b/src/basicfuns.jl
@@ -237,7 +237,7 @@ the data.
 logsumexp(X) = logsumexp_onepass(X)
 
 """
-    logsumexp(X::AbstractArray{<:Real}[; dims=:])
+    logsumexp(X::AbstractArray{<:Real}; dims=:)
 
 Compute `log.(sum(exp.(X); dims=dims))` in a numerically stable way that avoids
 intermediate over- and underflow.

--- a/src/basicfuns.jl
+++ b/src/basicfuns.jl
@@ -268,6 +268,10 @@ end
 
 # with initial element: required by CUDA
 function _logsumexp_onepass(X, ::Base.HasEltype)
+    # do not perform type computations if element type is abstract
+    T = eltype(X)
+    isconcretetype(T) || return _logsumexp_onepass(X, Base.EltypeUnknown())
+
     # compute initial element
     FT = float(eltype(X))
     init = (FT(-Inf), zero(FT))

--- a/src/basicfuns.jl
+++ b/src/basicfuns.jl
@@ -238,15 +238,7 @@ _logsumexp(X::AbstractArray{<:Real}, ::Colon) = logsumexp_onepass(X)
 function _logsumexp(X::AbstractArray{<:Real}, dims)
     # Do not use log(zero(eltype(X))) directly to avoid issues with ForwardDiff (#82)
     u = reduce(max, X, dims=dims, init=oftype(log(zero(eltype(X))), -Inf))
-    u isa AbstractArray || isfinite(u) || return float(u)
-    let u=u # avoid https://github.com/JuliaLang/julia/issues/15276
-        # TODO: remove the branch when JuliaLang/julia#31020 is merged.
-        if u isa AbstractArray
-            u .+ log.(sum(exp.(X .- u); dims=dims))
-        else
-            u + log(sum(x -> exp(x-u), X))
-        end
-    end
+    return u .+ log.(sum(exp.(X .- u); dims=dims))
 end
 
 """

--- a/src/basicfuns.jl
+++ b/src/basicfuns.jl
@@ -258,7 +258,6 @@ function logsumexp_onepass(X)
     # fallback for empty collections
     isempty(X) && return log(sum(X))
 
-    # perform single pass over the data
     xmax, r = _logsumexp_onepass(X, Base.IteratorEltype(X))
 
     return xmax + log(r)

--- a/test/basicfuns.jl
+++ b/test/basicfuns.jl
@@ -98,10 +98,8 @@ end
     @test logaddexp(10002, 10003) ≈ 10000 + logaddexp(2.0, 3.0)
 
     @test logsumexp([1.0, 2.0, 3.0])          ≈ 3.40760596444438
-    @test logsumexp_onepass([1.0, 2.0, 3.0])  ≈ 3.40760596444438
     @test logsumexp((1.0, 2.0, 3.0))          ≈ 3.40760596444438
     @test logsumexp([1.0, 2.0, 3.0] .+ 1000.) ≈ 1003.40760596444438
-    @test logsumexp_onepass([1.0, 2.0, 3.0] .+ 1000.) ≈ 1003.40760596444438
 
     @test logsumexp([[1.0, 2.0, 3.0] [1.0, 2.0, 3.0] .+ 1000.]; dims=1) ≈ [3.40760596444438 1003.40760596444438]
     @test logsumexp([[1.0 2.0 3.0]; [1.0 2.0 3.0] .+ 1000.]; dims=2) ≈ [3.40760596444438, 1003.40760596444438]
@@ -117,7 +115,6 @@ end
         for (arguments, result) in cases
             @test logaddexp(arguments...) ≡ result
             @test logsumexp(arguments) ≡ result
-            @test logsumexp_onepass(arguments) ≡ result
         end
     end
 
@@ -141,10 +138,6 @@ end
     @test isnan(logsumexp([NaN, 9.0]))
     @test isnan(logsumexp([NaN, Inf]))
     @test isnan(logsumexp([NaN, -Inf]))
-
-    @test isnan(logsumexp_onepass([NaN, 9.0]))
-    @test isnan(logsumexp_onepass([NaN, Inf]))
-    @test isnan(logsumexp_onepass([NaN, -Inf]))
 
     # issue #63
     a = logsumexp(i for i in range(-500, stop = 10, length = 1000) if true)

--- a/test/basicfuns.jl
+++ b/test/basicfuns.jl
@@ -1,5 +1,4 @@
 using StatsFuns, Test
-using StatsFuns: logsumexp_onepass
 
 @testset "xlogx & xlogy" begin
     @test iszero(xlogx(0))
@@ -139,10 +138,9 @@ end
     @test isnan(logsumexp([NaN, Inf]))
     @test isnan(logsumexp([NaN, -Inf]))
 
-    # issue #63
-    a = logsumexp(i for i in range(-500, stop = 10, length = 1000) if true)
-    b = logsumexp(range(-500, stop = 10, length = 1000))
-    @test a == b
+    # logsumexp with general iterables (issue #63)
+    xs = range(-500, stop = 10, length = 1000)
+    @test logsumexp(x for x in xs) == logsumexp(xs)
 end
 
 @testset "softmax" begin

--- a/test/basicfuns.jl
+++ b/test/basicfuns.jl
@@ -96,13 +96,18 @@ end
     @test logaddexp(2.0, 3.0)     ≈ log(exp(2.0) + exp(3.0))
     @test logaddexp(10002, 10003) ≈ 10000 + logaddexp(2.0, 3.0)
 
-    @test logsumexp([1.0, 2.0, 3.0])          ≈ 3.40760596444438
-    @test logsumexp((1.0, 2.0, 3.0))          ≈ 3.40760596444438
+    @test @inferred(logsumexp([1.0])) == 1.0
+    @test @inferred(logsumexp((x for x in [1.0]))) == 1.0
+    @test @inferred(logsumexp([1.0, 2.0, 3.0])) ≈ 3.40760596444438
+    @test @inferred(logsumexp((1.0, 2.0, 3.0))) ≈ 3.40760596444438
     @test logsumexp([1.0, 2.0, 3.0] .+ 1000.) ≈ 1003.40760596444438
 
-    @test logsumexp([[1.0, 2.0, 3.0] [1.0, 2.0, 3.0] .+ 1000.]; dims=1) ≈ [3.40760596444438 1003.40760596444438]
-    @test logsumexp([[1.0 2.0 3.0]; [1.0 2.0 3.0] .+ 1000.]; dims=2) ≈ [3.40760596444438, 1003.40760596444438]
-    @test logsumexp([[1.0, 2.0, 3.0] [1.0, 2.0, 3.0] .+ 1000.]; dims=[1,2]) ≈ [1003.4076059644444]
+    @test @inferred(logsumexp([[1.0, 2.0, 3.0] [1.0, 2.0, 3.0] .+ 1000.]; dims=1)) ≈ [3.40760596444438 1003.40760596444438]
+    @test @inferred(logsumexp([[1.0 2.0 3.0]; [1.0 2.0 3.0] .+ 1000.]; dims=2)) ≈ [3.40760596444438, 1003.40760596444438]
+    @test @inferred(logsumexp([[1.0, 2.0, 3.0] [1.0, 2.0, 3.0] .+ 1000.]; dims=[1,2])) ≈ [1003.4076059644444]
+
+    # check underflow
+    @test logsumexp([1e-20, log(1e-20)]) ≈ 2e-20
 
     let cases = [([-Inf, -Inf], -Inf),   # correct handling of all -Inf
                  ([-Inf, -Inf32], -Inf), # promotion
@@ -140,7 +145,7 @@ end
 
     # logsumexp with general iterables (issue #63)
     xs = range(-500, stop = 10, length = 1000)
-    @test logsumexp(x for x in xs) == logsumexp(xs)
+    @test @inferred(logsumexp(x for x in xs)) == logsumexp(xs)
 end
 
 @testset "softmax" begin

--- a/test/basicfuns.jl
+++ b/test/basicfuns.jl
@@ -1,4 +1,5 @@
 using StatsFuns, Test
+using StatsFuns: logsumexp_onepass
 
 @testset "xlogx & xlogy" begin
     @test iszero(xlogx(0))
@@ -97,8 +98,10 @@ end
     @test logaddexp(10002, 10003) ≈ 10000 + logaddexp(2.0, 3.0)
 
     @test logsumexp([1.0, 2.0, 3.0])          ≈ 3.40760596444438
+    @test logsumexp_onepass([1.0, 2.0, 3.0])  ≈ 3.40760596444438
     @test logsumexp((1.0, 2.0, 3.0))          ≈ 3.40760596444438
     @test logsumexp([1.0, 2.0, 3.0] .+ 1000.) ≈ 1003.40760596444438
+    @test logsumexp_onepass([1.0, 2.0, 3.0] .+ 1000.) ≈ 1003.40760596444438
 
     @test logsumexp([[1.0, 2.0, 3.0] [1.0, 2.0, 3.0] .+ 1000.]; dims=1) ≈ [3.40760596444438 1003.40760596444438]
     @test logsumexp([[1.0 2.0 3.0]; [1.0 2.0 3.0] .+ 1000.]; dims=2) ≈ [3.40760596444438, 1003.40760596444438]
@@ -114,6 +117,7 @@ end
         for (arguments, result) in cases
             @test logaddexp(arguments...) ≡ result
             @test logsumexp(arguments) ≡ result
+            @test logsumexp_onepass(arguments) ≡ result
         end
     end
 
@@ -137,6 +141,10 @@ end
     @test isnan(logsumexp([NaN, 9.0]))
     @test isnan(logsumexp([NaN, Inf]))
     @test isnan(logsumexp([NaN, -Inf]))
+
+    @test isnan(logsumexp_onepass([NaN, 9.0]))
+    @test isnan(logsumexp_onepass([NaN, Inf]))
+    @test isnan(logsumexp_onepass([NaN, -Inf]))
 end
 
 @testset "softmax" begin

--- a/test/basicfuns.jl
+++ b/test/basicfuns.jl
@@ -145,6 +145,11 @@ end
     @test isnan(logsumexp_onepass([NaN, 9.0]))
     @test isnan(logsumexp_onepass([NaN, Inf]))
     @test isnan(logsumexp_onepass([NaN, -Inf]))
+
+    # issue #63
+    a = logsumexp(i for i in range(-500, stop = 10, length = 1000) if true)
+    b = logsumexp(range(-500, stop = 10, length = 1000))
+    @test a == b
 end
 
 @testset "softmax" begin


### PR DESCRIPTION
This PR fixes https://github.com/JuliaStats/StatsFuns.jl/issues/91.

I used the streaming algorithm for the computation of logsumexp described in http://www.nowozin.net/sebastian/blog/streaming-log-sum-exp-computation.html in one of my projects lately, and I noticed that there is already an open issue for adding it to StatsFuns.

I reran the benchmark mentioned in the issue and got:
```julia
julia> using StatsFuns, BenchmarkTools, Random

julia> Random.seed!(100);

julia> n = 10_000_000;

julia> X = 500 .* randn(n);

julia> @btime logsumexp($X)
  94.999 ms (0 allocations: 0 bytes)
2697.6523838563817

julia> @btime StatsFuns.logsumexp_onepass($X)
  32.815 ms (0 allocations: 0 bytes)
2697.6523838563817

julia> f(X) = reduce(logaddexp, X)
f (generic function with 1 method)

julia> @btime f($X)
  162.519 ms (0 allocations: 0 bytes)
2697.6523838563817
```

Currently `logsumexp_onepass` is used as the fallback for `logsumexp` but not exported. I'm not sure if it should be exported as well. Additionally, maybe it would be beneficial to use the one-pass algorithms even for arrays above a certain size, since it seems to perform better in the benchmark above. Some additional benchmarks suggest that this might be the case even for smaller arrays:
```julia
julia> n = 10;

julia> Random.seed!(100);

julia> X = 500 .* randn(n);

julia> @btime logsumexp($X)
  84.612 ns (0 allocations: 0 bytes)
1016.2819596629249

julia> @btime StatsFuns.logsumexp_onepass($X)
  87.535 ns (0 allocations: 0 bytes)
1016.2819596629249

julia> @btime f($X)
  184.664 ns (0 allocations: 0 bytes)
1016.2819596629249

julia> n = 100;

julia> Random.seed!(100);

julia> X = 500 .* randn(n);

julia> @btime logsumexp($X)
  633.000 ns (0 allocations: 0 bytes)
1786.3178411042175

julia> @btime StatsFuns.logsumexp_onepass($X)
  654.025 ns (0 allocations: 0 bytes)
1786.3178411042175

julia> @btime f($X)
  1.337 μs (0 allocations: 0 bytes)
1786.3178411042175

julia> n = 1_000;

julia> Random.seed!(100);

julia> X = 500 .* randn(n);

julia> @btime logsumexp($X)
  6.698 μs (0 allocations: 0 bytes)
1786.3178411042175

julia> @btime StatsFuns.logsumexp_onepass($X)
  3.854 μs (0 allocations: 0 bytes)
1786.3178411042175

julia> @btime f($X)
  11.460 μs (0 allocations: 0 bytes)
1786.3178411042175
```

__Edit:__ This PR also fixes the example in https://github.com/JuliaStats/StatsFuns.jl/issues/63:

```julia
julia> logsumexp(i for i in range(-500, stop = 10, length = 1000) if true) - logsumexp(range(-500, stop = 10, length = 1000))
0.0
```

Additionally, it addresses (and fixes?) https://github.com/JuliaStats/StatsFuns.jl/issues/75 (but maybe we would still want the two-pass algorithm instead?).