### PR TITLE
Run CI tests on Julia LTS, stable, and nightly

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,7 +1,7 @@
 environment:
   matrix:
+  - julia_version: 1.0
   - julia_version: 1
-  - julia_version: 1.3
   - julia_version: nightly
 
 platform:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ os:
 
 julia:
   - 1.0
-  - 1.3
+  - 1
   - nightly
 
 notifications:


### PR DESCRIPTION
Addresses https://github.com/JuliaStats/StatsFuns.jl/pull/97#pullrequestreview-465192954.

Currently, StatsFuns is tested with Julia 1.3, stable, and nightly on AppVeyor and Julia 1.0, 1.3, and nightly on Travis. With this PR the package is tested with Julia 1.0, stable, and nightly on both AppVeyor and Travis.