### PR TITLE
Use julia implementations for pdfs and some cdf-like functions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,6 +14,7 @@ SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 
 [compat]
 ChainRulesCore = "1"
+HypergeometricFunctions = "0.3"
 InverseFunctions = "0.1"
 IrrationalConstants = "0.1"
 LogExpFunctions = "0.3.2"

--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ version = "0.9.15"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
+HypergeometricFunctions = "34004b35-14d8-5ef3-9330-4cdb6864b03a"
 InverseFunctions = "3587e190-3f89-42d0-90ee-14403ec27112"
 IrrationalConstants = "92d709cd-6900-40b7-9082-c6be49f344b6"
 LogExpFunctions = "2ab3a3ac-af41-5b50-aa03-7779005ae688"

--- a/src/distrs/beta.jl
+++ b/src/distrs/beta.jl
@@ -1,15 +1,17 @@
 # functions related to beta distributions
 
+using HypergeometricFunctions: _₂F₁
+
 # R implementations
 using .RFunctions:
     # betapdf,
     # betalogpdf,
-    betacdf,
-    betaccdf,
-    betalogcdf,
-    betalogccdf,
-    betainvcdf,
-    betainvccdf,
+    # betacdf,
+    # betaccdf,
+    # betalogcdf,
+    # betalogccdf,
+    # betainvcdf,
+    # betainvccdf,
     betainvlogcdf,
     betainvlogccdf
 
@@ -23,3 +25,46 @@ function betalogpdf(α::T, β::T, x::T) where {T<:Real}
     val = xlogy(α - 1, y) + xlog1py(β - 1, -y) - logbeta(α, β)
     return x < 0 || x > 1 ? oftype(val, -Inf) : val
 end
+
+betacdf(α::Float64, β::Float64, x::Float64) = first(beta_inc(α, β, x))
+betacdf(α::Real, β::Real, x::Real) = betacdf(promote(float(α), β, x)...)
+betacdf(k::T, x::T) where T = throw(MethodError(betacdf, (α, β, x)))
+
+betaccdf(α::Float64, β::Float64, x::Float64) = last(beta_inc(α, β, x))
+betaccdf(α::Real, β::Real, x::Real) = betaccdf(promote(float(α), β, x)...)
+betaccdf(k::T, x::T) where T = throw(MethodError(betaccdf, (α, β, x)))
+
+# The log version is currently based on non-log version. When the cdf is very small we shift
+# to an implementation based on the hypergeometric function ₂F₁ to avoid underflow.
+function betalogcdf(α::Float64, β::Float64, x::Float64)
+    p, q = beta_inc(α, β, x)
+    if p < eps(one(p))
+        # see https://dlmf.nist.gov/8.17#E7
+        return -log(α) + α*log(x) + log(_₂F₁(promote(α, 1 - β, α + 1, x)...)) - logbeta(α, β)
+    elseif p <= 0.7
+        return log(p)
+    else
+        return log1p(-q)
+    end
+end
+betalogcdf(α::Real, β::Real, x::Real) = betalogcdf(promote(float(α), β, x)...)
+betalogcdf(k::T, x::T) where T = throw(MethodError(betalogcdf, (α, β, x)))
+
+function betalogccdf(α::Float64, β::Float64, x::Float64)
+    p, q = beta_inc(α, β, x)
+    if q < 0.7
+        return log(q)
+    else
+        return log1p(-p)
+    end
+end
+betalogccdf(α::Real, β::Real, x::Real) = betalogccdf(promote(float(α), β, x)...)
+betalogccdf(α::T, β::T, x::T) where T = throw(MethodError(betalogccdf, (α, β, x)))
+
+betainvcdf(α::Float64, β::Float64, p::Float64) = first(beta_inc_inv(α, β, p, 1 - p))
+betainvcdf(α::Real, β::Real, p::Real) = betainvcdf(promote(float(α), β, p)...)
+betainvcdf(α::T, β::T, p::T) where T = throw(MethodError(betainvcdf, (α, β, p)))
+
+betainvccdf(α::Float64, β::Float64, p::Float64) = first(beta_inc_inv(α, β, 1 - p, p))
+betainvccdf(α::Real, β::Real, p::Real) = betainvccdf(promote(float(α), β, p)...)
+betainvccdf(α::T, β::T, p::T) where T = throw(MethodError(betainvccdf, (α, β, p)))

--- a/src/distrs/beta.jl
+++ b/src/distrs/beta.jl
@@ -32,17 +32,18 @@ betaccdf(α::Real, β::Real, x::Real) = last(beta_inc(α, β, x))
 
 # The log version is currently based on non-log version. When the cdf is very small we shift
 # to an implementation based on the hypergeometric function ₂F₁ to avoid underflow.
-function betalogcdf(α::Real, β::Real, x::Real)
+function betalogcdf(α::T, β::T, x::T) where {T<:Real}
     p, q = beta_inc(α, β, x)
     if p < eps(one(p))
         # see https://dlmf.nist.gov/8.17#E7
-        return -log(α) + α*log(x) + log(_₂F₁(promote(α, 1 - β, α + 1, x)...)) - logbeta(α, β)
+        return -log(α) + xlogy(α, x) + log(_₂F₁(promote(α, 1 - β, α + 1, x)...)) - logbeta(α, β)
     elseif p <= 0.7
         return log(p)
     else
         return log1p(-q)
     end
 end
+betalogcdf(α::Real, β::Real, x::Real) = betalogcdf(promote(α, β, x)...)
 
 function betalogccdf(α::Real, β::Real, x::Real)
     p, q = beta_inc(α, β, x)

--- a/src/distrs/beta.jl
+++ b/src/distrs/beta.jl
@@ -26,17 +26,13 @@ function betalogpdf(α::T, β::T, x::T) where {T<:Real}
     return x < 0 || x > 1 ? oftype(val, -Inf) : val
 end
 
-betacdf(α::Float64, β::Float64, x::Float64) = first(beta_inc(α, β, x))
-betacdf(α::Real, β::Real, x::Real) = betacdf(promote(float(α), β, x)...)
-betacdf(k::T, x::T) where T = throw(MethodError(betacdf, (α, β, x)))
+betacdf(α::Real, β::Real, x::Real) = first(beta_inc(α, β, x))
 
-betaccdf(α::Float64, β::Float64, x::Float64) = last(beta_inc(α, β, x))
-betaccdf(α::Real, β::Real, x::Real) = betaccdf(promote(float(α), β, x)...)
-betaccdf(k::T, x::T) where T = throw(MethodError(betaccdf, (α, β, x)))
+betaccdf(α::Real, β::Real, x::Real) = last(beta_inc(α, β, x))
 
 # The log version is currently based on non-log version. When the cdf is very small we shift
 # to an implementation based on the hypergeometric function ₂F₁ to avoid underflow.
-function betalogcdf(α::Float64, β::Float64, x::Float64)
+function betalogcdf(α::Real, β::Real, x::Real)
     p, q = beta_inc(α, β, x)
     if p < eps(one(p))
         # see https://dlmf.nist.gov/8.17#E7
@@ -47,10 +43,8 @@ function betalogcdf(α::Float64, β::Float64, x::Float64)
         return log1p(-q)
     end
 end
-betalogcdf(α::Real, β::Real, x::Real) = betalogcdf(promote(float(α), β, x)...)
-betalogcdf(k::T, x::T) where T = throw(MethodError(betalogcdf, (α, β, x)))
 
-function betalogccdf(α::Float64, β::Float64, x::Float64)
+function betalogccdf(α::Real, β::Real, x::Real)
     p, q = beta_inc(α, β, x)
     if q < 0.7
         return log(q)
@@ -58,13 +52,7 @@ function betalogccdf(α::Float64, β::Float64, x::Float64)
         return log1p(-p)
     end
 end
-betalogccdf(α::Real, β::Real, x::Real) = betalogccdf(promote(float(α), β, x)...)
-betalogccdf(α::T, β::T, x::T) where T = throw(MethodError(betalogccdf, (α, β, x)))
 
-betainvcdf(α::Float64, β::Float64, p::Float64) = first(beta_inc_inv(α, β, p, 1 - p))
-betainvcdf(α::Real, β::Real, p::Real) = betainvcdf(promote(float(α), β, p)...)
-betainvcdf(α::T, β::T, p::T) where T = throw(MethodError(betainvcdf, (α, β, p)))
+betainvcdf(α::Real, β::Real, p::Real) = first(beta_inc_inv(α, β, p, 1 - p))
 
-betainvccdf(α::Float64, β::Float64, p::Float64) = first(beta_inc_inv(α, β, 1 - p, p))
-betainvccdf(α::Real, β::Real, p::Real) = betainvccdf(promote(float(α), β, p)...)
-betainvccdf(α::T, β::T, p::T) where T = throw(MethodError(betainvccdf, (α, β, p)))
+betainvccdf(α::Real, β::Real, p::Real) = first(beta_inc_inv(α, β, 1 - p, p))

--- a/src/distrs/beta.jl
+++ b/src/distrs/beta.jl
@@ -1,8 +1,9 @@
 # functions related to beta distributions
 
 # R implementations
-# For pdf and logpdf we use the Julia implementation
 using .RFunctions:
+    # betapdf,
+    # betalogpdf,
     betacdf,
     betaccdf,
     betalogcdf,

--- a/src/distrs/beta.jl
+++ b/src/distrs/beta.jl
@@ -53,6 +53,6 @@ function betalogccdf(α::Real, β::Real, x::Real)
     end
 end
 
-betainvcdf(α::Real, β::Real, p::Real) = first(beta_inc_inv(α, β, p, 1 - p))
+betainvcdf(α::Real, β::Real, p::Real) = first(beta_inc_inv(α, β, p))
 
-betainvccdf(α::Real, β::Real, p::Real) = first(beta_inc_inv(α, β, 1 - p, p))
+betainvccdf(α::Real, β::Real, p::Real) = last(beta_inc_inv(α, β, p))

--- a/src/distrs/beta.jl
+++ b/src/distrs/beta.jl
@@ -26,17 +26,18 @@ function betalogpdf(α::T, β::T, x::T) where {T<:Real}
     return x < 0 || x > 1 ? oftype(val, -Inf) : val
 end
 
-betacdf(α::Real, β::Real, x::Real) = first(beta_inc(α, β, x))
+betacdf(α::Real, β::Real, x::Real) = first(beta_inc(α, β, min(max(0, x), 1)))
 
-betaccdf(α::Real, β::Real, x::Real) = last(beta_inc(α, β, x))
+betaccdf(α::Real, β::Real, x::Real) = last(beta_inc(α, β, min(max(0, x), 1)))
 
 # The log version is currently based on non-log version. When the cdf is very small we shift
 # to an implementation based on the hypergeometric function ₂F₁ to avoid underflow.
 function betalogcdf(α::T, β::T, x::T) where {T<:Real}
-    p, q = beta_inc(α, β, x)
+    _x = min(max(0, x), 1)
+    p, q = beta_inc(α, β, _x)
     if p < eps(one(p))
         # see https://dlmf.nist.gov/8.17#E7
-        return -log(α) + xlogy(α, x) + log(_₂F₁(promote(α, 1 - β, α + 1, x)...)) - logbeta(α, β)
+        return -log(α) + xlogy(α, _x) + log(_₂F₁(promote(α, 1 - β, α + 1, _x)...)) - logbeta(α, β)
     elseif p <= 0.7
         return log(p)
     else
@@ -46,7 +47,7 @@ end
 betalogcdf(α::Real, β::Real, x::Real) = betalogcdf(promote(α, β, x)...)
 
 function betalogccdf(α::Real, β::Real, x::Real)
-    p, q = beta_inc(α, β, x)
+    p, q = beta_inc(α, β, min(max(0, x), 1))
     if q < 0.7
         return log(q)
     else

--- a/src/distrs/beta.jl
+++ b/src/distrs/beta.jl
@@ -32,7 +32,7 @@ function betacdf(α::Real, β::Real, x::Real)
         return float(last(promote(α, β, x, x >= 0)))
     end
 
-    return first(beta_inc(α, β, min(max(0, x), 1)))
+    return first(beta_inc(α, β, clamp(x, 0, 1)))
 end
 
 function betaccdf(α::Real, β::Real, x::Real)
@@ -41,7 +41,7 @@ function betaccdf(α::Real, β::Real, x::Real)
         return float(last(promote(α, β, x, x < 0)))
     end
 
-    last(beta_inc(α, β, min(max(0, x), 1)))
+    last(beta_inc(α, β, clamp(x, 0, 1)))
 end
 
 # The log version is currently based on non-log version. When the cdf is very small we shift
@@ -52,7 +52,7 @@ function betalogcdf(α::T, β::T, x::T) where {T<:Real}
         return log(last(promote(α, β, x, x >= 0)))
     end
 
-    _x = min(max(0, x), 1)
+    _x = clamp(x, 0, 1)
     p, q = beta_inc(α, β, _x)
     if p < floatmin(p)
         # see https://dlmf.nist.gov/8.17#E7
@@ -71,7 +71,7 @@ function betalogccdf(α::Real, β::Real, x::Real)
         return log(last(promote(α, β, x, x < 0)))
     end
 
-    p, q = beta_inc(α, β, min(max(0, x), 1))
+    p, q = beta_inc(α, β, clamp(x, 0, 1))
     if q < 0.7
         return log(q)
     else

--- a/src/distrs/beta.jl
+++ b/src/distrs/beta.jl
@@ -26,13 +26,32 @@ function betalogpdf(α::T, β::T, x::T) where {T<:Real}
     return x < 0 || x > 1 ? oftype(val, -Inf) : val
 end
 
-betacdf(α::Real, β::Real, x::Real) = first(beta_inc(α, β, min(max(0, x), 1)))
+function betacdf(α::Real, β::Real, x::Real)
+    # Handle a degenerate case
+    if iszero(α)
+        return float(last(promote(α, β, x, x >= 0)))
+    end
 
-betaccdf(α::Real, β::Real, x::Real) = last(beta_inc(α, β, min(max(0, x), 1)))
+    return first(beta_inc(α, β, min(max(0, x), 1)))
+end
+
+function betaccdf(α::Real, β::Real, x::Real)
+    # Handle a degenerate case
+    if iszero(α)
+        return float(last(promote(α, β, x, x < 0)))
+    end
+
+    last(beta_inc(α, β, min(max(0, x), 1)))
+end
 
 # The log version is currently based on non-log version. When the cdf is very small we shift
 # to an implementation based on the hypergeometric function ₂F₁ to avoid underflow.
 function betalogcdf(α::T, β::T, x::T) where {T<:Real}
+    # Handle a degenerate case
+    if iszero(α)
+        return log(last(promote(α, β, x, x >= 0)))
+    end
+
     _x = min(max(0, x), 1)
     p, q = beta_inc(α, β, _x)
     if p < floatmin(p)
@@ -47,6 +66,11 @@ end
 betalogcdf(α::Real, β::Real, x::Real) = betalogcdf(promote(α, β, x)...)
 
 function betalogccdf(α::Real, β::Real, x::Real)
+    # Handle a degenerate case
+    if iszero(α)
+        return log(last(promote(α, β, x, x < 0)))
+    end
+
     p, q = beta_inc(α, β, min(max(0, x), 1))
     if q < 0.7
         return log(q)

--- a/src/distrs/beta.jl
+++ b/src/distrs/beta.jl
@@ -28,7 +28,7 @@ end
 
 function betacdf(α::Real, β::Real, x::Real)
     # Handle a degenerate case
-    if iszero(α)
+    if iszero(α) && β > 0
         return float(last(promote(α, β, x, x >= 0)))
     end
 
@@ -37,7 +37,7 @@ end
 
 function betaccdf(α::Real, β::Real, x::Real)
     # Handle a degenerate case
-    if iszero(α)
+    if iszero(α) && β > 0
         return float(last(promote(α, β, x, x < 0)))
     end
 
@@ -48,7 +48,7 @@ end
 # to an implementation based on the hypergeometric function ₂F₁ to avoid underflow.
 function betalogcdf(α::T, β::T, x::T) where {T<:Real}
     # Handle a degenerate case
-    if iszero(α)
+    if iszero(α) && β > 0
         return log(last(promote(x, x >= 0)))
     end
 
@@ -67,7 +67,7 @@ betalogcdf(α::Real, β::Real, x::Real) = betalogcdf(promote(α, β, x)...)
 
 function betalogccdf(α::Real, β::Real, x::Real)
     # Handle a degenerate case
-    if iszero(α)
+    if iszero(α) && β > 0
         return log(last(promote(α, β, x, x < 0)))
     end
 

--- a/src/distrs/beta.jl
+++ b/src/distrs/beta.jl
@@ -35,7 +35,7 @@ betaccdf(α::Real, β::Real, x::Real) = last(beta_inc(α, β, min(max(0, x), 1))
 function betalogcdf(α::T, β::T, x::T) where {T<:Real}
     _x = min(max(0, x), 1)
     p, q = beta_inc(α, β, _x)
-    if p < eps(one(p))
+    if p < floatmin(p)
         # see https://dlmf.nist.gov/8.17#E7
         return -log(α) + xlogy(α, _x) + log(_₂F₁(promote(α, 1 - β, α + 1, _x)...)) - logbeta(α, β)
     elseif p <= 0.7

--- a/src/distrs/beta.jl
+++ b/src/distrs/beta.jl
@@ -56,4 +56,4 @@ end
 
 betainvcdf(α::Real, β::Real, p::Real) = first(beta_inc_inv(α, β, p))
 
-betainvccdf(α::Real, β::Real, p::Real) = last(beta_inc_inv(α, β, p))
+betainvccdf(α::Real, β::Real, p::Real) = last(beta_inc_inv(β, α, p))

--- a/src/distrs/beta.jl
+++ b/src/distrs/beta.jl
@@ -49,7 +49,7 @@ end
 function betalogcdf(α::T, β::T, x::T) where {T<:Real}
     # Handle a degenerate case
     if iszero(α)
-        return log(last(promote(α, β, x, x >= 0)))
+        return log(last(promote(x, x >= 0)))
     end
 
     _x = clamp(x, 0, 1)

--- a/src/distrs/binom.jl
+++ b/src/distrs/binom.jl
@@ -4,10 +4,10 @@
 using .RFunctions:
     # binompdf,
     # binomlogpdf,
-    binomcdf,
-    binomccdf,
-    binomlogcdf,
-    binomlogccdf,
+    # binomcdf,
+    # binomccdf,
+    # binomlogcdf,
+    # binomlogccdf,
     binominvcdf,
     binominvccdf,
     binominvlogcdf,
@@ -23,3 +23,11 @@ function binomlogpdf(n::T, p::T, k::T) where {T<:Real}
     val = min(0, betalogpdf(m + 1, n - m + 1, p) - log(n + 1))
     return 0 <= k <= n && isinteger(k) ? val : oftype(val, -Inf)
 end
+
+binomcdf(n::Real, p::Real, k::Real) = betaccdf(k + 1, n - k, p)
+
+binomccdf(n::Real, p::Real, k::Real) = betacdf(k + 1, n - k, p)
+
+binomlogcdf(n::Real, p::Real, k::Real) = betalogccdf(k + 1, n - k, p)
+
+binomlogccdf(n::Real, p::Real, k::Real) = betalogcdf(k + 1, n - k, p)

--- a/src/distrs/binom.jl
+++ b/src/distrs/binom.jl
@@ -1,8 +1,9 @@
 # functions related to binomial distribution
 
 # R implementations
-# For pdf and logpdf we use the Julia implementation
 using .RFunctions:
+    # binompdf,
+    # binomlogpdf,
     binomcdf,
     binomccdf,
     binomlogcdf,

--- a/src/distrs/binom.jl
+++ b/src/distrs/binom.jl
@@ -13,7 +13,6 @@ using .RFunctions:
     binominvlogcdf,
     binominvlogccdf
 
-
 # Julia implementations
 binompdf(n::Real, p::Real, k::Real) = exp(binomlogpdf(n, p, k))
 

--- a/src/distrs/binom.jl
+++ b/src/distrs/binom.jl
@@ -30,6 +30,19 @@ for l in ("", "log"), compl in (false, true)
         if isnan(k)
             return last(promote(n, p, k))
         end
-        return ($fbeta)(max(0, floor(k) + 1), max(0, n - floor(k)), p)
+        res = ($fbeta)(max(0, floor(k) + 1), max(0, n - floor(k)), p)
+
+        # When p == 1 the betaccdf doesn't return the correct result
+        # so these cases have to be special cased
+        if isone(p)
+            newres = oftype(res, $compl ? k < n : k >= n)
+            if $l === ""
+                return newres
+            else
+                return log(newres)
+            end
+        else
+            return res
+        end
     end
 end

--- a/src/distrs/binom.jl
+++ b/src/distrs/binom.jl
@@ -36,11 +36,7 @@ for l in ("", "log"), compl in (false, true)
         # so these cases have to be special cased
         if isone(p)
             newres = oftype(res, $compl ? k < n : k >= n)
-            if $l === ""
-                return newres
-            else
-                return log(newres)
-            end
+            return $(l === "" ? :newres : :(log(newres)))
         else
             return res
         end

--- a/src/distrs/binom.jl
+++ b/src/distrs/binom.jl
@@ -23,10 +23,13 @@ function binomlogpdf(n::T, p::T, k::T) where {T<:Real}
     return 0 <= k <= n && isinteger(k) ? val : oftype(val, -Inf)
 end
 
-binomcdf(n::Real, p::Real, k::Real) = betaccdf(max(0, floor(k) + 1), max(0, n - floor(k)), p)
-
-binomccdf(n::Real, p::Real, k::Real) = betacdf(max(0, floor(k) + 1), max(0, n - floor(k)), p)
-
-binomlogcdf(n::Real, p::Real, k::Real) = betalogccdf(max(0, floor(k) + 1), max(0, n - floor(k)), p)
-
-binomlogccdf(n::Real, p::Real, k::Real) = betalogcdf(max(0, floor(k) + 1), max(0, n - floor(k)), p)
+for l in ("", "log"), compl in (false, true)
+    fbinom = Symbol(string("binom", l, ifelse(compl, "c", "" ), "cdf"))
+    fbeta  = Symbol(string("beta" , l, ifelse(compl,  "", "c"), "cdf"))
+    @eval function ($fbinom)(n::Real, p::Real, k::Real)
+        if isnan(k)
+            return last(promote(n, p, k))
+        end
+        return ($fbeta)(max(0, floor(k) + 1), max(0, n - floor(k)), p)
+    end
+end

--- a/src/distrs/binom.jl
+++ b/src/distrs/binom.jl
@@ -23,10 +23,10 @@ function binomlogpdf(n::T, p::T, k::T) where {T<:Real}
     return 0 <= k <= n && isinteger(k) ? val : oftype(val, -Inf)
 end
 
-binomcdf(n::Real, p::Real, k::Real) = betaccdf(k + 1, n - k, p)
+binomcdf(n::Real, p::Real, k::Real) = betaccdf(max(0, floor(k) + 1), max(0, n - floor(k)), p)
 
-binomccdf(n::Real, p::Real, k::Real) = betacdf(k + 1, n - k, p)
+binomccdf(n::Real, p::Real, k::Real) = betacdf(max(0, floor(k) + 1), max(0, n - floor(k)), p)
 
-binomlogcdf(n::Real, p::Real, k::Real) = betalogccdf(k + 1, n - k, p)
+binomlogcdf(n::Real, p::Real, k::Real) = betalogccdf(max(0, floor(k) + 1), max(0, n - floor(k)), p)
 
-binomlogccdf(n::Real, p::Real, k::Real) = betalogcdf(k + 1, n - k, p)
+binomlogccdf(n::Real, p::Real, k::Real) = betalogcdf(max(0, floor(k) + 1), max(0, n - floor(k)), p)

--- a/src/distrs/chisq.jl
+++ b/src/distrs/chisq.jl
@@ -4,12 +4,12 @@
 using .RFunctions:
     # chisqpdf,
     # chisqlogpdf,
-    chisqcdf,
-    chisqccdf,
+    # chisqcdf,
+    # chisqccdf,
     chisqlogcdf,
-    chisqlogccdf,
-    chisqinvcdf,
-    chisqinvccdf,
+    # chisqlogccdf,
+    # chisqinvcdf,
+    # chisqinvccdf,
     chisqinvlogcdf,
     chisqinvlogccdf
 
@@ -21,3 +21,23 @@ chisqpdf(k::T, x::T) where {T<:Real} = gammapdf(k / 2, 2, x)
 
 chisqlogpdf(k::Real, x::Real) = chisqlogpdf(promote(k, x)...)
 chisqlogpdf(k::T, x::T) where {T<:Real} = gammalogpdf(k / 2, 2, x)
+
+chisqcdf(k::Float64, x::Float64) = first(gamma_inc(k/2, x/2, 0))
+chisqcdf(k::Real, x::Real) = chisqcdf(promote(float(k), x)...)
+chisqcdf(k::T, x::T) where T = throw(MethodError(chisqcdf, (k, x)))
+
+chisqccdf(k::Float64, x::Float64) = last(gamma_inc(k/2, x/2, 0))
+chisqccdf(k::Real, x::Real) = chisqccdf(promote(float(k), x)...)
+chisqccdf(k::T, x::T) where T = throw(MethodError(chisqccdf, (k, x)))
+
+chisqlogccdf(k::Float64, x::Float64) = loggamma(k/2, x/2) - loggamma(k/2)
+chisqlogccdf(k::Real, x::Real) = chisqlogccdf(promote(float(k), x)...)
+chisqlogccdf(k::T, x::T) where T = throw(MethodError(chisqlogccdf, (k, x)))
+
+chisqinvcdf(k::Float64, p::Float64) = 2*gamma_inc_inv(k/2, p, 1 - p)
+chisqinvcdf(k::Real, p::Real) = chisqinvcdf(promote(float(k), p)...)
+chisqinvcdf(k::T, p::T) where T = throw(MethodError(chisqinvcdf, (k, p)))
+
+chisqinvccdf(k::Float64, p::Float64) = 2*gamma_inc_inv(k/2, 1 - p, p)
+chisqinvccdf(k::Real, p::Real) = chisqinvccdf(promote(float(k), p)...)
+chisqinvccdf(k::T, p::T) where T = throw(MethodError(chisqinvccdf, (k, p)))

--- a/src/distrs/chisq.jl
+++ b/src/distrs/chisq.jl
@@ -1,8 +1,9 @@
 # functions related to chi-square distribution
 
 # R implementations
-# For pdf and logpdf we use the Julia implementation
 using .RFunctions:
+    # chisqpdf,
+    # chisqlogpdf,
     chisqcdf,
     chisqccdf,
     chisqlogcdf,

--- a/src/distrs/chisq.jl
+++ b/src/distrs/chisq.jl
@@ -1,43 +1,8 @@
 # functions related to chi-square distribution
 
-# R implementations
-using .RFunctions:
-    # chisqpdf,
-    # chisqlogpdf,
-    # chisqcdf,
-    # chisqccdf,
-    chisqlogcdf,
-    # chisqlogccdf,
-    # chisqinvcdf,
-    # chisqinvccdf,
-    chisqinvlogcdf,
-    chisqinvlogccdf
-
-# Julia implementations
-# promotion ensures that we do forward e.g. `chisqpdf(::Int, ::Float32)` to
-# `gammapdf(::Float32, ::Int, ::Float32)` but not `gammapdf(::Float64, ::Int, ::Float32)`
-chisqpdf(k::Real, x::Real) = chisqpdf(promote(k, x)...)
-chisqpdf(k::T, x::T) where {T<:Real} = gammapdf(k / 2, 2, x)
-
-chisqlogpdf(k::Real, x::Real) = chisqlogpdf(promote(k, x)...)
-chisqlogpdf(k::T, x::T) where {T<:Real} = gammalogpdf(k / 2, 2, x)
-
-chisqcdf(k::Float64, x::Float64) = first(gamma_inc(k/2, x/2, 0))
-chisqcdf(k::Real, x::Real) = chisqcdf(promote(float(k), x)...)
-chisqcdf(k::T, x::T) where T = throw(MethodError(chisqcdf, (k, x)))
-
-chisqccdf(k::Float64, x::Float64) = last(gamma_inc(k/2, x/2, 0))
-chisqccdf(k::Real, x::Real) = chisqccdf(promote(float(k), x)...)
-chisqccdf(k::T, x::T) where T = throw(MethodError(chisqccdf, (k, x)))
-
-chisqlogccdf(k::Float64, x::Float64) = loggamma(k/2, x/2) - loggamma(k/2)
-chisqlogccdf(k::Real, x::Real) = chisqlogccdf(promote(float(k), x)...)
-chisqlogccdf(k::T, x::T) where T = throw(MethodError(chisqlogccdf, (k, x)))
-
-chisqinvcdf(k::Float64, p::Float64) = 2*gamma_inc_inv(k/2, p, 1 - p)
-chisqinvcdf(k::Real, p::Real) = chisqinvcdf(promote(float(k), p)...)
-chisqinvcdf(k::T, p::T) where T = throw(MethodError(chisqinvcdf, (k, p)))
-
-chisqinvccdf(k::Float64, p::Float64) = 2*gamma_inc_inv(k/2, 1 - p, p)
-chisqinvccdf(k::Real, p::Real) = chisqinvccdf(promote(float(k), p)...)
-chisqinvccdf(k::T, p::T) where T = throw(MethodError(chisqinvccdf, (k, p)))
+# Just use the Gamma definitions
+for f in ("pdf", "logpdf", "cdf", "ccdf", "logcdf", "logccdf", "invcdf", "invccdf", "invlogcdf", "invlogccdf")
+    _chisqf = Symbol("chisq"*f)
+    _gammaf = Symbol("gamma"*f)
+    @eval $(_chisqf)(k::Real, x::Real) = $(_gammaf)(k/2, 2, x)
+end

--- a/src/distrs/chisq.jl
+++ b/src/distrs/chisq.jl
@@ -4,5 +4,8 @@
 for f in ("pdf", "logpdf", "cdf", "ccdf", "logcdf", "logccdf", "invcdf", "invccdf", "invlogcdf", "invlogccdf")
     _chisqf = Symbol("chisq"*f)
     _gammaf = Symbol("gamma"*f)
-    @eval $(_chisqf)(k::Real, x::Real) = $(_gammaf)(k/2, 2, x)
+    @eval begin
+        $(_chisqf)(k::Real, x::Real) = $(_chisqf)(promote(k, x)...)
+        $(_chisqf)(k::T, x::T) where {T<:Real} = $(_gammaf)(k/2, 2, x)
+    end
 end

--- a/src/distrs/fdist.jl
+++ b/src/distrs/fdist.jl
@@ -1,8 +1,9 @@
 # functions related to F distribution
 
 # R implementations
-# For pdf and logpdf we use the Julia implementation
 using .RFunctions:
+    # fdistpdf,
+    # fdistlogpdf,
     fdistcdf,
     fdistccdf,
     fdistlogcdf,

--- a/src/distrs/fdist.jl
+++ b/src/distrs/fdist.jl
@@ -1,18 +1,5 @@
 # functions related to F distribution
 
-# R implementations
-using .RFunctions:
-    # fdistpdf,
-    # fdistlogpdf,
-    fdistcdf,
-    fdistccdf,
-    fdistlogcdf,
-    fdistlogccdf,
-    fdistinvcdf,
-    fdistinvccdf,
-    fdistinvlogcdf,
-    fdistinvlogccdf
-
 # Julia implementations
 fdistpdf(ν1::Real, ν2::Real, x::Real) = exp(fdistlogpdf(ν1, ν2, x))
 
@@ -23,4 +10,10 @@ function fdistlogpdf(ν1::T, ν2::T, x::T) where {T<:Real}
     y = max(x, 0)
     val = (xlogy(ν1, ν1ν2) + xlogy(ν1 - 2, y) - xlogy(ν1 + ν2, 1 + ν1ν2 * y)) / 2 - logbeta(ν1 / 2, ν2 / 2)
     return x < 0 ? oftype(val, -Inf) : val
+end
+
+for f in ("cdf", "ccdf", "logcdf", "logccdf", "invcdf", "invccdf", "invlogcdf", "invlogccdf")
+    ff = Symbol("fdist"*f)
+    bf = Symbol("beta"*f)
+    @eval $ff(ν1::Real, ν2::Real, x::Real) = $bf(ν1/2, ν2/2, inv(1 + ν2/(ν2*x)))
 end

--- a/src/distrs/fdist.jl
+++ b/src/distrs/fdist.jl
@@ -12,8 +12,16 @@ function fdistlogpdf(ν1::T, ν2::T, x::T) where {T<:Real}
     return x < 0 ? oftype(val, -Inf) : val
 end
 
-for f in ("cdf", "ccdf", "logcdf", "logccdf", "invcdf", "invccdf", "invlogcdf", "invlogccdf")
+for f in ("cdf", "ccdf", "logcdf", "logccdf")
     ff = Symbol("fdist"*f)
     bf = Symbol("beta"*f)
     @eval $ff(ν1::Real, ν2::Real, x::Real) = $bf(ν1/2, ν2/2, inv(1 + ν2/(ν2*max(0, x))))
+end
+for f in ("invcdf", "invccdf", "invlogcdf", "invlogccdf")
+    ff = Symbol("fdist"*f)
+    bf = Symbol("beta"*f)
+    @eval function $ff(ν1::Real, ν2::Real, y::Real)
+        x = $bf(ν1/2, ν2/2, y)
+        return x/(1 - x)*ν2/ν1
+    end
 end

--- a/src/distrs/fdist.jl
+++ b/src/distrs/fdist.jl
@@ -15,13 +15,15 @@ end
 for f in ("cdf", "ccdf", "logcdf", "logccdf")
     ff = Symbol("fdist"*f)
     bf = Symbol("beta"*f)
-    @eval $ff(ν1::Real, ν2::Real, x::Real) = $bf(ν1/2, ν2/2, inv(1 + ν2/(ν2*max(0, x))))
+    @eval $ff(ν1::T, ν2::T, x::T) where {T<:Real} = $bf(ν1/2, ν2/2, inv(1 + ν2/(ν2*max(0, x))))
+    @eval $ff(ν1::Real, ν2::Real, x::Real) = $ff(promote(ν1, ν2, x)...)
 end
 for f in ("invcdf", "invccdf", "invlogcdf", "invlogccdf")
     ff = Symbol("fdist"*f)
     bf = Symbol("beta"*f)
-    @eval function $ff(ν1::Real, ν2::Real, y::Real)
+    @eval function $ff(ν1::T, ν2::T, y::T) where {T<:Real}
         x = $bf(ν1/2, ν2/2, y)
         return x/(1 - x)*ν2/ν1
     end
+    @eval $ff(ν1::Real, ν2::Real, y::Real) = $ff(promote(ν1, ν2, y)...)
 end

--- a/src/distrs/fdist.jl
+++ b/src/distrs/fdist.jl
@@ -15,7 +15,7 @@ end
 for f in ("cdf", "ccdf", "logcdf", "logccdf")
     ff = Symbol("fdist"*f)
     bf = Symbol("beta"*f)
-    @eval $ff(ν1::T, ν2::T, x::T) where {T<:Real} = $bf(ν1/2, ν2/2, inv(1 + ν2/(ν2*max(0, x))))
+    @eval $ff(ν1::T, ν2::T, x::T) where {T<:Real} = $bf(ν1/2, ν2/2, inv(1 + ν2/(ν1*max(0, x))))
     @eval $ff(ν1::Real, ν2::Real, x::Real) = $ff(promote(ν1, ν2, x)...)
 end
 for f in ("invcdf", "invccdf", "invlogcdf", "invlogccdf")

--- a/src/distrs/fdist.jl
+++ b/src/distrs/fdist.jl
@@ -15,5 +15,5 @@ end
 for f in ("cdf", "ccdf", "logcdf", "logccdf", "invcdf", "invccdf", "invlogcdf", "invlogccdf")
     ff = Symbol("fdist"*f)
     bf = Symbol("beta"*f)
-    @eval $ff(ν1::Real, ν2::Real, x::Real) = $bf(ν1/2, ν2/2, inv(1 + ν2/(ν2*x)))
+    @eval $ff(ν1::Real, ν2::Real, x::Real) = $bf(ν1/2, ν2/2, inv(1 + ν2/(ν2*max(0, x))))
 end

--- a/src/distrs/gamma.jl
+++ b/src/distrs/gamma.jl
@@ -69,6 +69,12 @@ function _gammalogccdf(k::T, θ::T, x::T) where {T<:Union{Float16,Float32}}
     return T(_gammalogccdf(Float64(k), Float64(θ), Float64(x)))
 end
 
-gammainvcdf(k::Real, θ::Real, p::Real) = θ*gamma_inc_inv(k, p, 1 - p)
+function gammainvcdf(k::Real, θ::Real, p::Real)
+    _k, _θ, _p = map(float, promote(k, θ, p))
+    return _θ*gamma_inc_inv(_k, _p, 1 - _p)
+end
 
-gammainvccdf(k::Real, θ::Real, p::Real) = θ*gamma_inc_inv(k, 1 - p, p)
+function gammainvccdf(k::Real, θ::Real, p::Real)
+    _k, _θ, _p = map(float, promote(k, θ, p))
+    return _θ*gamma_inc_inv(_k, 1 - _p, _p)
+end

--- a/src/distrs/gamma.jl
+++ b/src/distrs/gamma.jl
@@ -1,15 +1,17 @@
 # functions related to gamma distribution
 
+using HypergeometricFunctions: drummond1F1
+
 # R implementations
 using .RFunctions:
     # gammapdf,
     # gammalogpdf,
-    gammacdf,
-    gammaccdf,
-    gammalogcdf,
-    gammalogccdf,
-    gammainvcdf,
-    gammainvccdf,
+    # gammacdf,
+    # gammaccdf,
+    # gammalogcdf,
+    # gammalogccdf,
+    # gammainvcdf,
+    # gammainvccdf,
     gammainvlogcdf,
     gammainvlogccdf
 
@@ -23,3 +25,49 @@ function gammalogpdf(k::T, θ::T, x::T) where {T<:Real}
     val = -loggamma(k) + xlogy(k - 1, xθ) - log(θ) - xθ
     return x < 0 ? oftype(val, -Inf) : val
 end
+
+gammacdf(k::T, θ::T, x::T) where {T<:Real} = first(gamma_inc(k, x/θ))
+gammacdf(k::Real, θ::Real, x::Real)        = gammacdf(promote(float(k), θ, x)...)
+gammacdf(k::T, θ::T, x::T) where T         = throw(MethodError(gammacdf, (k, θ, x)))
+
+gammaccdf(k::T, θ::T, x::T) where {T<:Real} = last(gamma_inc(k, x/θ))
+gammaccdf(k::Real, θ::Real, x::Real)        = gammaccdf(promote(float(k), θ, x)...)
+gammaccdf(k::T, θ::T, x::T) where T         = throw(MethodError(gammaccdf, (k, θ, x)))
+
+# Implemented via the non-log version. For tiny values, we recompute the result with
+# loggamma. In that situation, there is little risk of significant cancellation.
+function gammalogcdf(k::Float64, θ::Float64, x::Float64)
+    l, u = gamma_inc(k, x/θ)
+    if l < eps(Float64)
+        return -log(k) + k*log(x/θ) - x/θ + log(drummond1F1(1.0, 1 + k, x/θ)) - loggamma(k)
+    elseif l < 0.7
+        return log(l)
+    else
+        return log1p(-u)
+    end
+end
+gammalogcdf(k::Real, θ::Real, x::Real)        = gammalogcdf(promote(float(k), θ, x)...)
+gammalogcdf(k::T, θ::T, x::T) where T         = throw(MethodError(gammalogcdf, (k, θ, x)))
+
+# Implemented via the non-log version. For tiny values, we recompute the result with
+# loggamma. In that situation, there is little risk of significant cancellation.
+function gammalogccdf(k::Float64, θ::Float64, x::Float64)
+    l, u = gamma_inc(k, x/θ)
+    if u < eps(Float64)
+        return loggamma(k, x/θ) - loggamma(k)
+    elseif u < 0.7
+        return log(u)
+    else
+        return log1p(-l)
+    end
+end
+gammalogccdf(k::Real, θ::Real, x::Real)        = gammalogccdf(promote(float(k), θ, x)...)
+gammalogccdf(k::T, θ::T, x::T) where T         = throw(MethodError(gammalogccdf, (k, θ, x)))
+
+gammainvcdf(k::Float64, θ::Float64, p::Float64) = θ*gamma_inc_inv(k, p, 1 - p)
+gammainvcdf(k::Real, θ::Real, p::Real) = gammainvcdf(promote(float(k), θ, p)...)
+gammainvcdf(k::T, θ::T, p::T) where T = throw(MethodError(gammainvcdf, (k, θ, p)))
+
+gammainvccdf(k::Float64, θ::Float64, p::Float64) = θ*gamma_inc_inv(k, 1 - p, p)
+gammainvccdf(k::Real, θ::Real, p::Real) = gammainvccdf(promote(float(k), θ, p)...)
+gammainvccdf(k::T, θ::T, p::T) where T = throw(MethodError(gammainvccdf, (k, θ, p)))

--- a/src/distrs/gamma.jl
+++ b/src/distrs/gamma.jl
@@ -64,10 +64,6 @@ end
 gammalogccdf(k::Real, θ::Real, x::Real)        = gammalogccdf(promote(float(k), θ, x)...)
 gammalogccdf(k::T, θ::T, x::T) where T         = throw(MethodError(gammalogccdf, (k, θ, x)))
 
-gammainvcdf(k::Float64, θ::Float64, p::Float64) = θ*gamma_inc_inv(k, p, 1 - p)
-gammainvcdf(k::Real, θ::Real, p::Real) = gammainvcdf(promote(float(k), θ, p)...)
-gammainvcdf(k::T, θ::T, p::T) where T = throw(MethodError(gammainvcdf, (k, θ, p)))
+gammainvcdf(k::Real, θ::Real, p::Real) = θ*gamma_inc_inv(k, p, 1 - p)
 
-gammainvccdf(k::Float64, θ::Float64, p::Float64) = θ*gamma_inc_inv(k, 1 - p, p)
-gammainvccdf(k::Real, θ::Real, p::Real) = gammainvccdf(promote(float(k), θ, p)...)
-gammainvccdf(k::T, θ::T, p::T) where T = throw(MethodError(gammainvccdf, (k, θ, p)))
+gammainvccdf(k::Real, θ::Real, p::Real) = θ*gamma_inc_inv(k, 1 - p, p)

--- a/src/distrs/gamma.jl
+++ b/src/distrs/gamma.jl
@@ -1,8 +1,9 @@
 # functions related to gamma distribution
 
 # R implementations
-# For pdf and logpdf we use the Julia implementation
 using .RFunctions:
+    # gammapdf,
+    # gammalogpdf,
     gammacdf,
     gammaccdf,
     gammalogcdf,

--- a/src/distrs/gamma.jl
+++ b/src/distrs/gamma.jl
@@ -28,15 +28,15 @@ end
 
 gammacdf(k::T, θ::T, x::T) where {T<:Real} = first(gamma_inc(k, x/θ))
 gammacdf(k::Real, θ::Real, x::Real)        = gammacdf(promote(float(k), θ, x)...)
-gammacdf(k::T, θ::T, x::T) where T         = throw(MethodError(gammacdf, (k, θ, x)))
 
 gammaccdf(k::T, θ::T, x::T) where {T<:Real} = last(gamma_inc(k, x/θ))
 gammaccdf(k::Real, θ::Real, x::Real)        = gammaccdf(promote(float(k), θ, x)...)
-gammaccdf(k::T, θ::T, x::T) where T         = throw(MethodError(gammaccdf, (k, θ, x)))
+
+gammalogcdf(k::Real, θ::Real, x::Real) = _gammalogcdf(map(float, promote(k, θ, x))...)
 
 # Implemented via the non-log version. For tiny values, we recompute the result with
 # loggamma. In that situation, there is little risk of significant cancellation.
-function gammalogcdf(k::Float64, θ::Float64, x::Float64)
+function _gammalogcdf(k::Float64, θ::Float64, x::Float64)
     l, u = gamma_inc(k, x/θ)
     if l < eps(Float64)
         return -log(k) + k*log(x/θ) - x/θ + log(drummond1F1(1.0, 1 + k, x/θ)) - loggamma(k)
@@ -46,12 +46,15 @@ function gammalogcdf(k::Float64, θ::Float64, x::Float64)
         return log1p(-u)
     end
 end
-gammalogcdf(k::Real, θ::Real, x::Real)        = gammalogcdf(promote(float(k), θ, x)...)
-gammalogcdf(k::T, θ::T, x::T) where T         = throw(MethodError(gammalogcdf, (k, θ, x)))
+function _gammalogcdf(k::T, θ::T, x::T) where {T<:Union{Float16,Float32}}
+    return T(_gammalogcdf(Float64(k), Float64(θ), Float64(x)))
+end
+
+gammalogccdf(k::Real, θ::Real, x::Real) = _gammalogccdf(map(float, promote(k, θ, x))...)
 
 # Implemented via the non-log version. For tiny values, we recompute the result with
 # loggamma. In that situation, there is little risk of significant cancellation.
-function gammalogccdf(k::Float64, θ::Float64, x::Float64)
+function _gammalogccdf(k::Float64, θ::Float64, x::Float64)
     l, u = gamma_inc(k, x/θ)
     if u < eps(Float64)
         return loggamma(k, x/θ) - loggamma(k)
@@ -61,8 +64,10 @@ function gammalogccdf(k::Float64, θ::Float64, x::Float64)
         return log1p(-l)
     end
 end
-gammalogccdf(k::Real, θ::Real, x::Real)        = gammalogccdf(promote(float(k), θ, x)...)
-gammalogccdf(k::T, θ::T, x::T) where T         = throw(MethodError(gammalogccdf, (k, θ, x)))
+
+function _gammalogccdf(k::T, θ::T, x::T) where {T<:Union{Float16,Float32}}
+    return T(_gammalogccdf(Float64(k), Float64(θ), Float64(x)))
+end
 
 gammainvcdf(k::Real, θ::Real, p::Real) = θ*gamma_inc_inv(k, p, 1 - p)
 

--- a/src/distrs/gamma.jl
+++ b/src/distrs/gamma.jl
@@ -29,7 +29,7 @@ end
 function gammacdf(k::T, θ::T, x::T) where {T<:Real}
     # Handle the degenerate case
     if iszero(k)
-        return last(promote(k, θ, x, x >= 0))/one(θ)
+        return last(promote(k, θ, x, x >= 0))/sqrt(one(θ))
     end
     return first(gamma_inc(k, max(0, x)/θ))
 end
@@ -38,7 +38,7 @@ gammacdf(k::Real, θ::Real, x::Real) = gammacdf(map(float, promote(k, θ, x))...
 function gammaccdf(k::T, θ::T, x::T) where {T<:Real}
     # Handle the degenerate case
     if iszero(k)
-        return last(promote(k, θ, x, x < 0))/one(θ)
+        return last(promote(k, θ, x, x < 0))/sqrt(one(θ))
     end
     return last(gamma_inc(k, max(0, x)/θ))
 end
@@ -51,7 +51,7 @@ gammalogcdf(k::Real, θ::Real, x::Real) = _gammalogcdf(map(float, promote(k, θ,
 function _gammalogcdf(k::Float64, θ::Float64, x::Float64)
     # Handle the degenerate case
     if iszero(k)
-        return log(last(promote(k, θ, x, x >= 0))/one(θ))
+        return log(last(promote(k, θ, x, x >= 0))/sqrt(one(θ)))
     end
 
     xdθ = max(0, x)/θ
@@ -75,7 +75,7 @@ gammalogccdf(k::Real, θ::Real, x::Real) = _gammalogccdf(map(float, promote(k, �
 function _gammalogccdf(k::Float64, θ::Float64, x::Float64)
     # Handle the degenerate case
     if iszero(k)
-        return log(last(promote(k, θ, x, x < 0))/one(θ))
+        return log(last(promote(k, θ, x, x < 0))/sqrt(one(θ)))
     end
 
     xdθ = max(0, x)/θ

--- a/src/distrs/gamma.jl
+++ b/src/distrs/gamma.jl
@@ -75,7 +75,7 @@ gammalogccdf(k::Real, θ::Real, x::Real) = _gammalogccdf(map(float, promote(k, �
 function _gammalogccdf(k::Float64, θ::Float64, x::Float64)
     # Handle the degenerate case
     if iszero(k)
-        return log(last(promote(k, θ, x, x < 0))/sqrt(one(θ)))
+        return log(x < 0)
     end
 
     xdθ = max(0, x)/θ

--- a/src/distrs/gamma.jl
+++ b/src/distrs/gamma.jl
@@ -26,10 +26,10 @@ function gammalogpdf(k::T, θ::T, x::T) where {T<:Real}
     return x < 0 ? oftype(val, -Inf) : val
 end
 
-gammacdf(k::T, θ::T, x::T) where {T<:Real} = first(gamma_inc(k, x/θ))
+gammacdf(k::T, θ::T, x::T) where {T<:Real} = first(gamma_inc(k, max(0, x)/θ))
 gammacdf(k::Real, θ::Real, x::Real)        = gammacdf(promote(float(k), θ, x)...)
 
-gammaccdf(k::T, θ::T, x::T) where {T<:Real} = last(gamma_inc(k, x/θ))
+gammaccdf(k::T, θ::T, x::T) where {T<:Real} = last(gamma_inc(k, max(0, x)/θ))
 gammaccdf(k::Real, θ::Real, x::Real)        = gammaccdf(promote(float(k), θ, x)...)
 
 gammalogcdf(k::Real, θ::Real, x::Real) = _gammalogcdf(map(float, promote(k, θ, x))...)
@@ -37,7 +37,7 @@ gammalogcdf(k::Real, θ::Real, x::Real) = _gammalogcdf(map(float, promote(k, θ,
 # Implemented via the non-log version. For tiny values, we recompute the result with
 # loggamma. In that situation, there is little risk of significant cancellation.
 function _gammalogcdf(k::Float64, θ::Float64, x::Float64)
-    xdθ = x/θ
+    xdθ = max(0, x)/θ
     l, u = gamma_inc(k, xdθ)
     if l < eps(Float64)
         return -log(k) + k*log(xdθ) - xdθ + log(drummond1F1(1.0, 1 + k, xdθ)) - loggamma(k)
@@ -56,9 +56,10 @@ gammalogccdf(k::Real, θ::Real, x::Real) = _gammalogccdf(map(float, promote(k, �
 # Implemented via the non-log version. For tiny values, we recompute the result with
 # loggamma. In that situation, there is little risk of significant cancellation.
 function _gammalogccdf(k::Float64, θ::Float64, x::Float64)
-    l, u = gamma_inc(k, x/θ)
+    xdθ = max(0, x)/θ
+    l, u = gamma_inc(k, xdθ)
     if u < eps(Float64)
-        return loggamma(k, x/θ) - loggamma(k)
+        return loggamma(k, xdθ) - loggamma(k)
     elseif u < 0.7
         return log(u)
     else

--- a/src/distrs/gamma.jl
+++ b/src/distrs/gamma.jl
@@ -51,7 +51,7 @@ gammalogcdf(k::Real, θ::Real, x::Real) = _gammalogcdf(map(float, promote(k, θ,
 function _gammalogcdf(k::Float64, θ::Float64, x::Float64)
     # Handle the degenerate case
     if iszero(k)
-        return log(last(promote(k, θ, x, x >= 0))/sqrt(one(θ)))
+        return log(x >= 0)
     end
 
     xdθ = max(0, x)/θ

--- a/src/distrs/gamma.jl
+++ b/src/distrs/gamma.jl
@@ -39,7 +39,7 @@ gammalogcdf(k::Real, θ::Real, x::Real) = _gammalogcdf(map(float, promote(k, θ,
 function _gammalogcdf(k::Float64, θ::Float64, x::Float64)
     xdθ = max(0, x)/θ
     l, u = gamma_inc(k, xdθ)
-    if l < eps(Float64)
+    if l < eps(Float64) && isfinite(k) && isfinite(xdθ)
         return -log(k) + k*log(xdθ) - xdθ + log(drummond1F1(1.0, 1 + k, xdθ)) - loggamma(k)
     elseif l < 0.7
         return log(l)

--- a/src/distrs/gamma.jl
+++ b/src/distrs/gamma.jl
@@ -38,7 +38,7 @@ gammacdf(k::Real, θ::Real, x::Real) = gammacdf(map(float, promote(k, θ, x))...
 function gammaccdf(k::T, θ::T, x::T) where {T<:Real}
     # Handle the degenerate case
     if iszero(k)
-        return last(promote(k, θ, x, x < 0))/sqrt(one(θ))
+        return float(last(promote(x, x < 0)))
     end
     return last(gamma_inc(k, max(0, x)/θ))
 end

--- a/src/distrs/gamma.jl
+++ b/src/distrs/gamma.jl
@@ -37,9 +37,10 @@ gammalogcdf(k::Real, θ::Real, x::Real) = _gammalogcdf(map(float, promote(k, θ,
 # Implemented via the non-log version. For tiny values, we recompute the result with
 # loggamma. In that situation, there is little risk of significant cancellation.
 function _gammalogcdf(k::Float64, θ::Float64, x::Float64)
-    l, u = gamma_inc(k, x/θ)
+    xdθ = x/θ
+    l, u = gamma_inc(k, xdθ)
     if l < eps(Float64)
-        return -log(k) + k*log(x/θ) - x/θ + log(drummond1F1(1.0, 1 + k, x/θ)) - loggamma(k)
+        return -log(k) + k*log(xdθ) - xdθ + log(drummond1F1(1.0, 1 + k, xdθ)) - loggamma(k)
     elseif l < 0.7
         return log(l)
     else

--- a/src/distrs/gamma.jl
+++ b/src/distrs/gamma.jl
@@ -29,7 +29,7 @@ end
 function gammacdf(k::T, θ::T, x::T) where {T<:Real}
     # Handle the degenerate case
     if iszero(k)
-        return last(promote(k, θ, x, x >= 0))/sqrt(one(θ))
+        return float(last(promote(x, x >= 0)))
     end
     return first(gamma_inc(k, max(0, x)/θ))
 end

--- a/src/distrs/gamma.jl
+++ b/src/distrs/gamma.jl
@@ -33,7 +33,7 @@ function gammacdf(k::T, θ::T, x::T) where {T<:Real}
     end
     return first(gamma_inc(k, max(0, x)/θ))
 end
-gammacdf(k::Real, θ::Real, x::Real)        = gammacdf(promote(float(k), θ, x)...)
+gammacdf(k::Real, θ::Real, x::Real) = gammacdf(map(float, promote(k, θ, x))...)
 
 function gammaccdf(k::T, θ::T, x::T) where {T<:Real}
     # Handle the degenerate case
@@ -42,7 +42,7 @@ function gammaccdf(k::T, θ::T, x::T) where {T<:Real}
     end
     return last(gamma_inc(k, max(0, x)/θ))
 end
-gammaccdf(k::Real, θ::Real, x::Real)        = gammaccdf(promote(float(k), θ, x)...)
+gammaccdf(k::Real, θ::Real, x::Real) = gammaccdf(map(float, promote(k, θ, x))...)
 
 gammalogcdf(k::Real, θ::Real, x::Real) = _gammalogcdf(map(float, promote(k, θ, x))...)
 
@@ -94,11 +94,11 @@ function _gammalogccdf(k::T, θ::T, x::T) where {T<:Union{Float16,Float32}}
 end
 
 function gammainvcdf(k::Real, θ::Real, p::Real)
-    _k, _θ, _p = map(float, promote(k, θ, p))
+    _k, _θ, _p = promote(k, θ, p)
     return _θ*gamma_inc_inv(_k, _p, 1 - _p)
 end
 
 function gammainvccdf(k::Real, θ::Real, p::Real)
-    _k, _θ, _p = map(float, promote(k, θ, p))
+    _k, _θ, _p = promote(k, θ, p)
     return _θ*gamma_inc_inv(_k, 1 - _p, _p)
 end

--- a/src/distrs/pois.jl
+++ b/src/distrs/pois.jl
@@ -4,10 +4,10 @@
 using .RFunctions:
     # poispdf,
     # poislogpdf,
-    poiscdf,
-    poisccdf,
-    poislogcdf,
-    poislogccdf,
+    # poiscdf,
+    # poisccdf,
+    # poislogcdf,
+    # poislogccdf,
     poisinvcdf,
     poisinvccdf,
     poisinvlogcdf,
@@ -21,3 +21,12 @@ function poislogpdf(λ::T, x::T) where {T <: Real}
     val = xlogy(x, λ) - λ - loggamma(x + 1)
     return x >= 0 && isinteger(x) ? val : oftype(val, -Inf)
 end
+
+# Just use the Gamma definitions
+poiscdf(λ::Real, x::Real) = gammaccdf(floor(x + 1), 1, λ)
+
+poisccdf(λ::Real, x::Real) = gammacdf(floor(x + 1), 1, λ)
+
+poislogcdf(λ::Real, x::Real) = gammalogccdf(floor(x + 1), 1, λ)
+
+poislogccdf(λ::Real, x::Real) = gammalogcdf(floor(x + 1), 1, λ)

--- a/src/distrs/pois.jl
+++ b/src/distrs/pois.jl
@@ -1,8 +1,9 @@
 # functions related to Poisson distribution
 
 # R implementations
-# For pdf and logpdf we use the Julia implementation
 using .RFunctions:
+    # poispdf,
+    # poislogpdf,
     poiscdf,
     poisccdf,
     poislogcdf,

--- a/src/distrs/pois.jl
+++ b/src/distrs/pois.jl
@@ -23,10 +23,10 @@ function poislogpdf(λ::T, x::T) where {T <: Real}
 end
 
 # Just use the Gamma definitions
-poiscdf(λ::Real, x::Real) = gammaccdf(floor(x + 1), 1, λ)
+poiscdf(λ::Real, x::Real) = gammaccdf(max(0, floor(x + 1)), 1, λ)
 
-poisccdf(λ::Real, x::Real) = gammacdf(floor(x + 1), 1, λ)
+poisccdf(λ::Real, x::Real) = gammacdf(max(0, floor(x + 1)), 1, λ)
 
-poislogcdf(λ::Real, x::Real) = gammalogccdf(floor(x + 1), 1, λ)
+poislogcdf(λ::Real, x::Real) = gammalogccdf(max(0, floor(x + 1)), 1, λ)
 
-poislogccdf(λ::Real, x::Real) = gammalogcdf(floor(x + 1), 1, λ)
+poislogccdf(λ::Real, x::Real) = gammalogcdf(max(0, floor(x + 1)), 1, λ)

--- a/src/distrs/tdist.jl
+++ b/src/distrs/tdist.jl
@@ -1,8 +1,9 @@
 # functions related to student's T distribution
 
 # R implementations
-# For pdf and logpdf we use the Julia implementation
 using .RFunctions:
+    # tdistpdf,
+    # tdistlogpdf,
     tdistcdf,
     tdistccdf,
     tdistlogcdf,

--- a/test/rmath.jl
+++ b/test/rmath.jl
@@ -173,6 +173,10 @@ end
         # Test p=0.48 separately since R fails. (It's pretty slow, though, caused by the cdf being 9.0797754e-317)
         @test betainvcdf(1000, 2, betacdf(1000, 2, 0.48)) ≈ 0.48
     end
+    @testset "$(f)(0, 0, $x) should error" for f in (betacdf, betaccdf, betalogcdf, betalogccdf),
+        x in (0.0, 0.5, 1.0)
+        @test_throws DomainError f(0.0, 0.0, x)
+    end
 
     rmathcomp_tests("binom", [
         ((1, 0.5), 0.0:1.0),

--- a/test/rmath.jl
+++ b/test/rmath.jl
@@ -79,47 +79,68 @@ function rmathcomp(basename, params, X::AbstractArray, rtol)
     end
     rmath_rand = has_rand ? get_rmathfun(rand) : nothing
 
-    for x in X
+    # for x in X
         if has_pdf
-            check_rmath(pdf, stats_pdf, rmath_pdf,
-                params, "x", x, true, rtol)
-            check_rmath(logpdf, stats_logpdf, rmath_logpdf,
-                params, "x", x, false, rtol)
+            @testset "pdf" begin
+                check_rmath.(pdf, stats_pdf, rmath_pdf,
+                    Ref(params), "x", X, true, rtol)
+            end
+            @testset "logpdf" begin
+                check_rmath.(logpdf, stats_logpdf, rmath_logpdf,
+                    Ref(params), "x", X, false, rtol)
+            end
         end
-        check_rmath(cdf, stats_cdf, rmath_cdf,
-            params, "x", x, true, rtol)
-        check_rmath(ccdf, stats_ccdf, rmath_ccdf,
-            params, "x", x, true, rtol)
-        check_rmath(logcdf, stats_logcdf, rmath_logcdf,
-            params, "x", x, false, rtol)
-        check_rmath(logccdf, stats_logccdf, rmath_logccdf,
-            params, "x", x, false, rtol)
+        @testset "cdf" begin
+            check_rmath.(cdf, stats_cdf, rmath_cdf,
+                Ref(params), "x", X, true, rtol)
+        end
+        @testset "ccdf" begin
+            check_rmath.(ccdf, stats_ccdf, rmath_ccdf,
+                Ref(params), "x", X, true, rtol)
+        end
+        @testset "logcdf" begin
+            check_rmath.(logcdf, stats_logcdf, rmath_logcdf,
+                Ref(params), "x", X, false, rtol)
+        end
+        @testset "logccdf" begin
+            check_rmath.(logccdf, stats_logccdf, rmath_logccdf,
+                Ref(params), "x", X, false, rtol)
+        end
 
-        p = rmath_cdf(params..., x)
-        cp = rmath_ccdf(params..., x)
-        lp = rmath_logcdf(params..., x)
-        lcp = rmath_logccdf(params..., x)
+        p = rmath_cdf.(params..., X)
+        cp = rmath_ccdf.(params..., X)
+        lp = rmath_logcdf.(params..., X)
+        lcp = rmath_logccdf.(params..., X)
 
-        check_rmath(invcdf, stats_invcdf, rmath_invcdf,
-            params, "q", p, false, rtol)
-        check_rmath(invccdf, stats_invccdf, rmath_invccdf,
-            params, "q", cp, false, rtol)
-        check_rmath(invlogcdf, stats_invlogcdf, rmath_invlogcdf,
-            params, "lq", lp, false, rtol)
-        check_rmath(invlogccdf, stats_invlogccdf, rmath_invlogccdf,
-            params, "lq", lcp, false, rtol)
+        @testset "invcdf" begin
+            check_rmath.(invcdf, stats_invcdf, rmath_invcdf,
+                Ref(params), "q", p, false, rtol)
+        end
+        @testset "invccdf" begin
+            check_rmath.(invccdf, stats_invccdf, rmath_invccdf,
+                Ref(params), "q", cp, false, rtol)
+        end
+        @testset "invlogcdf" begin
+            check_rmath.(invlogcdf, stats_invlogcdf, rmath_invlogcdf,
+                Ref(params), "lq", lp, false, rtol)
+        end
+        @testset "invlogccdf" begin
+            check_rmath.(invlogccdf, stats_invlogccdf, rmath_invlogccdf,
+                Ref(params), "lq", lcp, false, rtol)
+        end
 
         # make sure that rand works
         if has_rand
             rmath_rand(params...)
         end
-    end
+    # end
 end
 
 function rmathcomp_tests(basename, configs)
-    println("\ttesting $basename ...")
-    for (params, data) in configs
-        rmathcomp(basename, params, data)
+    @testset "$basename" begin
+        @testset "params: $params" for (params, data) in configs
+            rmathcomp(basename, params, data)
+        end
     end
 end
 

--- a/test/rmath.jl
+++ b/test/rmath.jl
@@ -174,22 +174,6 @@ end
         @test betainvcdf(1000, 2, betacdf(1000, 2, 0.48)) ≈ 0.48
     end
 
-    # We test the following extreme parameters separately since
-    # a slightly larger tolerance is needed.
-    #
-    # For `betapdf(1000, 2, 0.58)`:
-    # StatsFuns:   1.9419987107407202e-231
-    # Rmath:       1.941998710740941e-231
-    # Mathematica: 1.941998710742487e-231
-    # For `betapdf(1000, 2, 0.68)`:
-    # StatsFuns:   1.5205049885199752e-162
-    # Rmath:       1.5205049885200616e-162
-    # Mathematica: 1.520504988521358e-162
-    @testset "Beta(1000, 2)" begin
-        rmathcomp("beta", (1000, 2), setdiff(0.0:0.01:1.0, (0.58, 0.68)))
-        rmathcomp("beta", (1000, 2), [0.58, 0.68], 1e-12)
-    end
-
     rmathcomp_tests("binom", [
         ((1, 0.5), 0.0:1.0),
         ((1, 0.7), 0.0:1.0),


### PR DESCRIPTION
I think we should begin to use Julia implementations when they are available. There is is really no need to call out to Rmath when we have implementations available. Eventually, we should then also be able to drop Rmath as a package dependency and just use it for testing although there is still some work to do. However, SpecialFunctions now has some of the more tricky functions available so we can get quite far. This has a conflict with https://github.com/JuliaStats/StatsFuns.jl/pull/112 so it would be good to get than one merged first and I can update this PR afterwards.