### PR TITLE
Cancel Github actions for previous commits in PRs

### DIFF
--- a/.github/workflows/IntegrationTest.yml
+++ b/.github/workflows/IntegrationTest.yml
@@ -9,6 +9,12 @@ on:
       - master
     tags: '*'
 
+concurrency:
+  # Skip intermediate builds: always.
+  # Cancel intermediate builds: only if it is a pull request build.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+
 jobs:
   test:
     name: ${{ matrix.package.repo }}/${{ matrix.package.group }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
         continue-on-error: true
-      - uses: codecov/codecov-action@v1
+      - uses: codecov/codecov-action@v2
         continue-on-error: true
         with:
           file: lcov.info

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,5 @@
 name: CI
 
-env:
-  JULIA_NUM_THREADS: 2
-
 on:
   pull_request:
     branches:
@@ -17,6 +14,9 @@ concurrency:
   # Cancel intermediate builds: only if it is a pull request build.
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+
+env:
+  JULIA_NUM_THREADS: 2
 
 jobs:
   test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,8 +52,6 @@ jobs:
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
-        continue-on-error: true
       - uses: codecov/codecov-action@v2
-        continue-on-error: true
         with:
           file: lcov.info

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
 name: CI
+
 env:
   JULIA_NUM_THREADS: 2
+
 on:
   pull_request:
     branches:
@@ -9,6 +11,13 @@ on:
     branches:
       - master
     tags: '*'
+
+concurrency:
+  # Skip intermediate builds: always.
+  # Cancel intermediate builds: only if it is a pull request build.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+
 jobs:
   test:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
@@ -43,6 +52,8 @@ jobs:
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
+        continue-on-error: true
       - uses: codecov/codecov-action@v1
+        continue-on-error: true
         with:
           file: lcov.info

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 Mathematical functions related to statistics.
 
-[![Travis](https://travis-ci.com/JuliaStats/StatsFuns.jl.svg?branch=master)](https://travis-ci.com/JuliaStats/StatsFuns.jl)
-[![Coveralls](https://coveralls.io/repos/github/JuliaStats/StatsFuns.jl/badge.svg?branch=master)](https://coveralls.io/github/JuliaStats/StatsFuns.jl?branch=master)
+[![CI](https://github.com/JuliaStats/StatsFuns.jl/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/JuliaStats/StatsFuns.jl/actions/workflows/ci.yml?query=branch%3Amaster)
+[![codecov](https://codecov.io/gh/JuliaStats/StatsFuns.jl/branch/master/graph/badge.svg?token=CV9hGTr6cW)](https://codecov.io/gh/JuliaStats/StatsFuns.jl)
 
 This package provides a collection of mathematical constants and numerical functions for statistical computing.
 


### PR DESCRIPTION
This PR updates the Github actions setup and cancels runs for all but the latest commit in each PR automatically. I think this is particularly useful for the more time consuming integration tests. Additionally, coverage upload issues don't affect the status of the jobs anymore.