### PR TITLE
Promote arguments of `norminvcdf` and `norminvccdf`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "StatsFuns"
 uuid = "4c63d2b9-4356-54db-8cca-17b64c39e42c"
-version = "0.9.14"
+version = "0.9.15"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/distrs/norm.jl
+++ b/src/distrs/norm.jl
@@ -91,14 +91,14 @@ end
 norminvcdf(p::Real) = -erfcinv(2*p) * sqrt2
 function norminvcdf(μ::Real, σ::Real, p::Real)
     # Promote to ensure that we don't compute erfcinv in low precision and then promote
-    _μ, _σ, _p = map(float, promote(μ, σ, p))
+    _μ, _σ, _p = promote(μ, σ, p)
     xval(_μ, _σ, norminvcdf(_p))
 end
 
 norminvccdf(p::Real) = erfcinv(2*p) * sqrt2
 function norminvccdf(μ::Real, σ::Real, p::Real)
     # Promote to ensure that we don't compute erfcinv in low precision and then promote
-    _μ, _σ, _p = map(float, promote(μ, σ, p))
+    _μ, _σ, _p = promote(μ, σ, p)
     xval(_μ, _σ, norminvccdf(_p))
 end
 

--- a/src/distrs/norm.jl
+++ b/src/distrs/norm.jl
@@ -89,18 +89,14 @@ function normlogccdf(μ::Real, σ::Real, x::Number)
 end
 
 norminvcdf(p::Real) = -erfcinv(2*p) * sqrt2
-function norminvcdf(μ::Real, σ::Real, p::Real)
-    # Promote to ensure that we don't compute erfcinv in low precision and then promote
-    _μ, _σ, _p = promote(μ, σ, p)
-    xval(_μ, _σ, norminvcdf(_p))
-end
+# Promote to ensure that we don't compute erfcinv in low precision and then promote
+norminvcdf(μ::Real, σ::Real, p::Real) = norminvcdf(promote(μ, σ, p)...)
+norminvcdf(μ::T, σ::T, p::T) where {T<:Real} = xval(μ, σ, norminvcdf(p))
 
 norminvccdf(p::Real) = erfcinv(2*p) * sqrt2
-function norminvccdf(μ::Real, σ::Real, p::Real)
-    # Promote to ensure that we don't compute erfcinv in low precision and then promote
-    _μ, _σ, _p = promote(μ, σ, p)
-    xval(_μ, _σ, norminvccdf(_p))
-end
+# Promote to ensure that we don't compute erfcinv in low precision and then promote
+norminvccdf(μ::Real, σ::Real, p::Real) = norminvccdf(promote(μ, σ, p)...)
+norminvccdf(μ::T, σ::T, p::T) where {T<:Real} = xval(μ, σ, norminvccdf(p))
 
 # invlogcdf. Fixme! Support more precisions than Float64
 norminvlogcdf(lp::Union{Float16,Float32}) = convert(typeof(lp), _norminvlogcdf_impl(Float64(lp)))

--- a/src/distrs/norm.jl
+++ b/src/distrs/norm.jl
@@ -39,15 +39,15 @@ function normlogpdf(μ::Real, σ::Real, x::Number)
         z = zval(μ, σ, x)
     end
     normlogpdf(z) - log(σ)
-end            
+end
 
 # cdf
 normcdf(z::Number) = erfc(-z * invsqrt2)/2
 function normcdf(μ::Real, σ::Real, x::Number)
     if iszero(σ) && x == μ
         z = zval(zero(μ), σ, one(x))
-    else        
-        z = zval(μ, σ, x)        
+    else
+        z = zval(μ, σ, x)
     end
     normcdf(z)
 end
@@ -56,8 +56,8 @@ normccdf(z::Number) = erfc(z * invsqrt2)/2
 function normccdf(μ::Real, σ::Real, x::Number)
     if iszero(σ) && x == μ
         z = zval(zero(μ), σ, one(x))
-    else        
-        z = zval(μ, σ, x)        
+    else
+        z = zval(μ, σ, x)
     end
     normccdf(z)
 end
@@ -69,8 +69,8 @@ normlogcdf(z::Number) = z < -1.0 ?
 function normlogcdf(μ::Real, σ::Real, x::Number)
     if iszero(σ) && x == μ
         z = zval(zero(μ), σ, one(x))
-    else        
-        z = zval(μ, σ, x)        
+    else
+        z = zval(μ, σ, x)
     end
     normlogcdf(z)
 end
@@ -82,17 +82,25 @@ normlogccdf(z::Number) = z > 1.0 ?
 function normlogccdf(μ::Real, σ::Real, x::Number)
     if iszero(σ) && x == μ
         z = zval(zero(μ), σ, one(x))
-    else        
-        z = zval(μ, σ, x)        
+    else
+        z = zval(μ, σ, x)
     end
     normlogccdf(z)
 end
 
 norminvcdf(p::Real) = -erfcinv(2*p) * sqrt2
-norminvcdf(μ::Real, σ::Real, p::Real) = xval(μ, σ, norminvcdf(p))
+function norminvcdf(μ::Real, σ::Real, p::Real)
+    # Promote to ensure that we don't compute erfcinv in low precision and then promote
+    _μ, _σ, _p = map(float, promote(μ, σ, p))
+    xval(_μ, _σ, norminvcdf(_p))
+end
 
 norminvccdf(p::Real) = erfcinv(2*p) * sqrt2
-norminvccdf(μ::Real, σ::Real, p::Real) = xval(μ, σ, norminvccdf(p))
+function norminvccdf(μ::Real, σ::Real, p::Real)
+    # Promote to ensure that we don't compute erfcinv in low precision and then promote
+    _μ, _σ, _p = map(float, promote(μ, σ, p))
+    xval(_μ, _σ, norminvccdf(_p))
+end
 
 # invlogcdf. Fixme! Support more precisions than Float64
 norminvlogcdf(lp::Union{Float16,Float32}) = convert(typeof(lp), _norminvlogcdf_impl(Float64(lp)))

--- a/test/rmath.jl
+++ b/test/rmath.jl
@@ -17,17 +17,12 @@ end
 get_statsfun(fname) = eval(Symbol(fname))
 get_rmathfun(fname) = eval(Meta.parse(string("RFunctions.", fname)))
 
-function rmathcomp(basename, params, X::AbstractArray, rtol=nothing)
+function rmathcomp(basename, params, X::AbstractArray)
     # compute desired tolerance:
     # has to take into account `params` as well since otherwise e.g. `X::Array{<:Rational}`
     # always uses a tolerance based on `eps(one(Float64))` even when parameters are of type
     # Float32
-    rtol = if rtol === nothing
-        PT = Base.promote_typeof(params...)
-        100 * eps(float(one(promote_type(PT, eltype(X)))))
-    else
-        rtol
-    end
+    rtol = 100 * eps(float(one(promote_type(Base.promote_typeof(params...), eltype(X)))))
 
     # tackle pdf specially
     has_pdf = true

--- a/test/rmath.jl
+++ b/test/rmath.jl
@@ -23,7 +23,7 @@ function rmathcomp(basename, params, X::AbstractArray, rtol=nothing)
     # always uses a tolerance based on `eps(one(Float64))` even when parameters are of type
     # Float32
     rtol = if rtol === nothing
-        PT = mapreduce(typeof, promote_type, params)
+        PT = Base.promote_typeof(params...)
         100 * eps(float(one(promote_type(PT, eltype(X)))))
     else
         rtol

--- a/test/rmath.jl
+++ b/test/rmath.jl
@@ -18,12 +18,14 @@ get_statsfun(fname) = eval(Symbol(fname))
 get_rmathfun(fname) = eval(Meta.parse(string("RFunctions.", fname)))
 
 function rmathcomp(basename, params, X::AbstractArray)
-    # compute desired tolerance:
+    # compute default tolerance:
     # has to take into account `params` as well since otherwise e.g. `X::Array{<:Rational}`
     # always uses a tolerance based on `eps(one(Float64))` even when parameters are of type
     # Float32
     rtol = 100 * eps(float(one(promote_type(Base.promote_typeof(params...), eltype(X)))))
-
+    rmathcomp(basename, params, X, rtol)
+end
+function rmathcomp(basename, params, X::AbstractArray, rtol)
     # tackle pdf specially
     has_pdf = true
     if basename == "srdist"


### PR DESCRIPTION
Currently these functions compute `erfcinv` in possibly lower precision and only take into account the parameters (and their types) of the normal distribution afterwards. This PR fixes and tests this problem.