### PR TITLE
DO NOT MERGE: Trigger CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,8 @@ lstirling_asym
 
 ## Distribution-related functions
 
-Do note that this package only provides low-level distribution functions. We recommend using the [Distributions.jl](https://github.com/JuliaStats/Distributions.jl/) package for a more convenient interface.
+Do note that this package only provides low-level distribution functions.
+We recommend using the [Distributions.jl](https://github.com/JuliaStats/Distributions.jl/) package for a more convenient interface.
 
 ```julia
 # distrs/beta


### PR DESCRIPTION
This PR is just to trigger CI without breaking the badges on the master branch. I wonder if the remaining test failures in #155  are caused by the Rmath update (https://github.com/JuliaStats/Rmath.jl/pull/79).