### PR TITLE
Use promote_type instead of promote_eltype in misc tests

### DIFF
--- a/test/misc.jl
+++ b/test/misc.jl
@@ -56,7 +56,7 @@ end
                                       for eltyb in (Float32, Float64)
             a = rand(eltya)
             b = rand(eltyb)
-            T = Base.promote_eltype(eltya, eltyb)
+            T = Base.promote_type(eltya, eltyb)
             @test typeof(logmvbeta(1, a, b)) == T
         end
     end

--- a/test/rmath.jl
+++ b/test/rmath.jl
@@ -5,8 +5,17 @@ using Test
 include("utils.jl")
 
 function check_rmath(fname, statsfun, rmathfun, params, aname, a, isprob, rtol)
-    v = @inferred(statsfun(params..., a))
-    rv = @inferred(rmathfun(params..., a))
+    # HypergeometricFunctions@0.3.18 made some changes that trips inference
+    # on older versions of Julia. Not worth the the time trying to debug/fix
+    # as we might drop support for these version soon so just putting the
+    # inference check behind a VERSION branch
+    if VERSION >= v"1.7"
+        v = @inferred(statsfun(params..., a))
+        rv = @inferred(rmathfun(params..., a))
+    else
+        v = statsfun(params..., a)
+        rv = rmathfun(params..., a)
+    end
     @test v isa float(Base.promote_typeof(params..., a))
     @test rv isa float(Base.promote_typeof(params..., a))
     if isprob


### PR DESCRIPTION
I think this has been wrong from the beginning but just happened to work until Julia 1.10.

There are failures on Julia 1.6 related to inference. I've identified the regression to come from version 0.3.18 of `HypergeometricFunctions`. It's not at all clear why it happens and `Base.return_types` and `code_warntype` disagrees

```julia
julia> Base.return_types(betalogcdf, (Rational{Int}, Rational{Int}, Rational{Int}))
1-element Vector{Any}:
 Any

julia> code_warntype(betalogcdf, (Rational{Int}, Rational{Int}, Rational{Int}))
Variables
  #self#::Core.Const(StatsFuns.betalogcdf)
  α::Rational{Int64}
  β::Rational{Int64}
  x::Rational{Int64}
  @_5::Int64
  q::Float64
  p::Float64
  _x::Rational{Int64}

Body::Float64
...
```
not clear what we should do here.