### PR TITLE
add signrank distribution

### DIFF
--- a/src/StatsFuns.jl
+++ b/src/StatsFuns.jl
@@ -219,6 +219,18 @@ export
     tdistinvlogcdf,     # inverse-logcdf of student's t distribution
     tdistinvlogccdf,    # inverse-logccdf of student's t distribution
 
+    # distrs/signrank
+    signrankpdf,
+    signranklogpdf,
+    signrankcdf,
+    signranklogcdf,
+    signrankccdf,
+    signranklogccdf,
+    signrankinvcdf,
+    signrankinvccdf,
+    signrankinvlogcdf,
+    signrankinvlogccdf,
+            
     # distrs/srdist
     srdistcdf,           # cdf of studentized range distribution
     srdistccdf,          # ccdf of studentized range distribution
@@ -258,6 +270,7 @@ include(joinpath("distrs", "norm.jl"))
 include(joinpath("distrs", "ntdist.jl"))
 include(joinpath("distrs", "pois.jl"))
 include(joinpath("distrs", "tdist.jl"))
+include(joinpath("distrs", "signrank.jl"))
 include(joinpath("distrs", "srdist.jl"))
 
 if !isdefined(Base, :get_extension)

--- a/src/distrs/signrank.jl
+++ b/src/distrs/signrank.jl
@@ -1,0 +1,109 @@
+#=
+The signrank distribution is equivalent to the problem
+of finding the number of subsets of {1,2,...,n} summing to W,
+relative to the total number of subsets.
+The empty subset is defined to sum to zero.
+This can be calculated using the recursion:
+either n is in the subset in which case we need to calculate
+the number of subsets of {1,2,...,n-1} summing to W-n,
+or n is not in the subset in which case we need to calculate
+the number of subsets of {1,2,...,n-1} summing to W.
+This can be calculated bottom up using dynamic programming.
+
+The i'th element of DP in the j'th outer loop iteration represents:
+the number of ways {1,2,...,j} can sum to W-i+1.
+ =#
+
+@inline function signrankDP(n, W)
+    DP = zeros(Int, W + 1)
+    DP[W+1] = 1
+    for j in 1:n
+        for i in 1:(W+1-j)
+            DP[i] += DP[i+j]
+        end
+    end
+    return DP
+end
+
+function signrankpdf(n::Int, W::Union{Float64,Int})
+    f, _ = modf(W)
+    if f != 0
+        return 0.0
+    end
+    W = Int(W)
+    max_W = (n * (n + 1)) >> 1
+    if W < 0
+        return 0.0
+    elseif W > max_W >> 1
+        return signrankpdf(n, max_W - W)
+    end
+    DP = signrankDP(n, W)
+    return ldexp(float(DP[1]), -n)
+end
+
+function signranklogpdf(n::Int, W::Union{Float64,Int})
+    return log(signrankpdf(n, W))
+end
+
+function signrankcdf(n::Int, W::Union{Float64,Int})
+    W = round(Int, W, RoundNearestTiesUp)
+    max_W = (n * (n + 1)) >> 1
+    if W < 0
+        return 0.0
+    elseif W > max_W >> 1
+        return 1.0 - signrankcdf(n, max_W - W - 1)
+    end
+    DP = signrankDP(n, W)
+    return sum(Base.Fix2(ldexp, -n) ∘ float, DP)
+end
+
+function signranklogcdf(n::Int, W::Union{Float64,Int})
+    return log(signrankcdf(n, W))
+end
+
+function signrankccdf(n::Int, W::Union{Float64,Int})
+    max_W = (n * (n + 1)) >> 1
+    W = round(Int, W, RoundNearestTiesUp)
+    return signrankcdf(n, max_W - W - 1,)
+end
+
+function signranklogccdf(n::Int, W::Union{Float64,Int})
+    return log(signrankccdf(n, W))
+end
+
+function signrankinvcdf(n::Int, p::Float64)
+    if p < 0.0 || p > 1.0
+        return NaN
+    end
+    W = 0
+    while signrankcdf(n, W) < p # TODO binary search and symmetry
+        W += 1
+    end
+    return float(W)
+end
+
+function signrankinvlogcdf(n::Int, logp::Float64)
+    if logp > 0.0 || logp == -Inf
+        return NaN
+    end
+    W = 0
+    while signranklogcdf(n, W) < logp # TODO binary search and symmetry
+        W += 1
+    end
+    return float(W)
+end
+
+function signrankinvccdf(n::Int, p::Float64)
+    signrankinvcdf(n, 1 - p)
+end
+
+function signrankinvlogccdf(n::Int, logp::Float64)
+    if logp == -Inf
+        return NaN
+    end
+    if logp == 0
+        return 0.0
+    end
+    #signrankinvlogcdf(n, log1mexp(logp)) # does not roundtrip well
+    signrankinvccdf(n, exp(logp))
+end

--- a/src/rmath.jl
+++ b/src/rmath.jl
@@ -131,6 +131,7 @@ end
 
 ### Import specific functions
 
+@import_rmath signrank signrank n
 @import_rmath beta beta α β
 @import_rmath binom binom n p
 @import_rmath chisq chisq k

--- a/test/rmath.jl
+++ b/test/rmath.jl
@@ -44,10 +44,7 @@ function rmathcomp(basename, params, X::AbstractArray, rtol=_default_rtol(params
     This slight difference causes test failures for the inverse functions,
     due to a slight shift in the location of the discontinuity.
     =#
-    test_inv = true
-    if basename == "signrank" && Sys.islinux()
-        test_inv = false
-    end
+    test_inv = basename != "signrank" || !Sys.islinux()
 
     if has_pdf
         pdf     = string(basename, "pdf")

--- a/test/rmath.jl
+++ b/test/rmath.jl
@@ -44,9 +44,9 @@ function rmathcomp(basename, params, X::AbstractArray, rtol=_default_rtol(params
     This slight difference causes test failures for the inverse functions,
     due to a slight shift in the location of the discontinuity.
     =#
-    has_inv = true
+    test_inv = true
     if basename == "signrank" && Sys.islinux()
-        has_inv = false
+        test_inv = false
     end
 
     if has_pdf
@@ -57,7 +57,7 @@ function rmathcomp(basename, params, X::AbstractArray, rtol=_default_rtol(params
     ccdf    = string(basename, "ccdf")
     logcdf  = string(basename, "logcdf")
     logccdf = string(basename, "logccdf")
-    if has_inv
+    if test_inv
         invcdf     = string(basename, "invcdf")
         invccdf    = string(basename, "invccdf")
         invlogcdf  = string(basename, "invlogcdf")
@@ -73,7 +73,7 @@ function rmathcomp(basename, params, X::AbstractArray, rtol=_default_rtol(params
     stats_ccdf    = get_statsfun(ccdf)
     stats_logcdf  = get_statsfun(logcdf)
     stats_logccdf = get_statsfun(logccdf)
-    if has_inv
+    if test_inv
         stats_invcdf     = get_statsfun(invcdf)
         stats_invccdf    = get_statsfun(invccdf)
         stats_invlogcdf  = get_statsfun(invlogcdf)
@@ -88,7 +88,7 @@ function rmathcomp(basename, params, X::AbstractArray, rtol=_default_rtol(params
     rmath_ccdf    = get_rmathfun(ccdf)
     rmath_logcdf  = get_rmathfun(logcdf)
     rmath_logccdf = get_rmathfun(logccdf)
-    if has_inv
+    if test_inv
         rmath_invcdf     = get_rmathfun(invcdf)
         rmath_invccdf    = get_rmathfun(invccdf)
         rmath_invlogcdf  = get_rmathfun(invlogcdf)
@@ -134,7 +134,7 @@ function rmathcomp(basename, params, X::AbstractArray, rtol=_default_rtol(params
     lp = rmath_logcdf.(params..., X)
     lcp = rmath_logccdf.(params..., X)
 
-    if has_inv
+    if test_inv
         @testset "invcdf with q=$_p" for _p in p
             check_rmath(invcdf, stats_invcdf, rmath_invcdf,
                 params, "q", _p, false, rtol)
@@ -402,17 +402,10 @@ end
         ((4),-2:12),
         ((4),-2.0:0.25:12.0),
         ((10),-2:57),
-        #((50),-2:1277),
     ])
     
-    @test signrankinvcdf.(10, signrankcdf.(10, -1:56)) == [0; 0:55; 55]
-    @test signrankinvccdf.(10, signrankccdf.(10, -1:56)) == [0; 0:55; 55]
-    @test signrankinvlogcdf.(10, signranklogcdf.(10, 0:56)) == [0:55; 55]
-    @test isnan(signrankinvlogcdf.(10, signranklogcdf(10, -1)))
-    @test signrankinvlogccdf.(10, signranklogccdf.(10, -1:54)) == [0; 0:54]
-    @test isnan(signrankinvlogccdf.(10, signranklogccdf.(10, 55)))
-    @test isnan(signrankinvlogccdf.(10, signranklogccdf.(10, 56)))
-
+    # The R version does not roundtrip cdf->invcdf, while our version does
+    @test_broken RFunctions.signrankinvcdf.(50, RFunctions.signrankcdf.(50, -1:1276)) == [0; 0:1275; 1275]
     @test signrankinvcdf.(50, signrankcdf.(50, -1:1276)) == [0; 0:1275; 1275]
     @test signrankinvccdf.(50, signrankccdf.(50, -1:1276)) == [0; 0:1275; 1275]
     @test signrankinvlogcdf.(50, signranklogcdf.(50, 0:1276)) == [0:1275; 1275]

--- a/test/rmath.jl
+++ b/test/rmath.jl
@@ -215,7 +215,7 @@ end
             @test @inferred(betainvccdf(α, 0, p)) === 1f0
         end
     end
-
+    
     rmathcomp_tests("binom", [
         ((1, 0.5), 0.0:1.0),
         ((1, 0.7), 0.0:1.0),
@@ -375,6 +375,23 @@ end
         ((Inf,), -5.0:0.1:5.0),
         ((Inf32,), -5f0:0.1f0:5f0),
     ])
+
+    rmathcomp_tests("signrank", [
+        ((4),-2:12),
+        ((4),-2.0:0.25:12.0),
+        ((10),-2:57),
+        #((50),-2:1277),
+    ])
+    
+    @test signrankinvcdf.(10, signrankcdf.(10, -1:56)) ≈ [0; 0:55; 55] atol = 1e-12 rtol = 1e-12
+    @test signrankinvccdf.(10, signrankccdf.(10, -1:56)) ≈ [0; 0:55; 55] atol = 1e-12 rtol = 1e-12
+    @test signrankinvlogcdf.(10, signranklogcdf.(10, -1:56)) ≈ [NaN; 0:55; 55] nans = true atol = 1e-12 rtol = 1e-12
+    @test signrankinvlogccdf.(10, signranklogccdf.(10, -1:56)) ≈ [0; 0:54; NaN; NaN] nans = true atol = 1e-12 rtol = 1e-12
+
+    @test signrankinvcdf.(50, signrankcdf.(50, -1:1276)) ≈ [0; 0:1275; 1275] atol = 1e-12 rtol = 1e-12
+    @test signrankinvccdf.(50, signrankccdf.(50, -1:1276)) ≈ [0; 0:1275; 1275] atol = 1e-12 rtol = 1e-12
+    @test signrankinvlogcdf.(50, signranklogcdf.(50, -1:1276)) ≈ [NaN; 0:1275; 1275] nans = true atol = 1e-12 rtol = 1e-12
+    @test signrankinvlogccdf.(50, signranklogccdf.(50, -1:1276)) ≈ [0; 0:1274; NaN; NaN] nans = true atol = 1e-12 rtol = 1e-12
 
     rmathcomp_tests("srdist", [
         ((1,2), (0.0:0.2:5.0)),

--- a/test/rmath.jl
+++ b/test/rmath.jl
@@ -215,7 +215,7 @@ end
             @test @inferred(betainvccdf(α, 0, p)) === 1f0
         end
     end
-    
+
     rmathcomp_tests("binom", [
         ((1, 0.5), 0.0:1.0),
         ((1, 0.7), 0.0:1.0),
@@ -383,16 +383,22 @@ end
         #((50),-2:1277),
     ])
     
-    @test signrankinvcdf.(10, signrankcdf.(10, -1:56)) ≈ [0; 0:55; 55] atol = 1e-12 rtol = 1e-12
-    @test signrankinvccdf.(10, signrankccdf.(10, -1:56)) ≈ [0; 0:55; 55] atol = 1e-12 rtol = 1e-12
-    @test signrankinvlogcdf.(10, signranklogcdf.(10, -1:56)) ≈ [NaN; 0:55; 55] nans = true atol = 1e-12 rtol = 1e-12
-    @test signrankinvlogccdf.(10, signranklogccdf.(10, -1:56)) ≈ [0; 0:54; NaN; NaN] nans = true atol = 1e-12 rtol = 1e-12
+    @test signrankinvcdf.(10, signrankcdf.(10, -1:56)) == [0; 0:55; 55]
+    @test signrankinvccdf.(10, signrankccdf.(10, -1:56)) == [0; 0:55; 55]
+    @test signrankinvlogcdf.(10, signranklogcdf.(10, 0:56)) == [0:55; 55]
+    @test isnan(signrankinvlogcdf.(10, signranklogcdf(10, -1)))
+    @test signrankinvlogccdf.(10, signranklogccdf.(10, -1:54)) == [0; 0:54]
+    @test isnan(signrankinvlogccdf.(10, signranklogccdf.(10, 55)))
+    @test isnan(signrankinvlogccdf.(10, signranklogccdf.(10, 56)))
 
-    @test signrankinvcdf.(50, signrankcdf.(50, -1:1276)) ≈ [0; 0:1275; 1275] atol = 1e-12 rtol = 1e-12
-    @test signrankinvccdf.(50, signrankccdf.(50, -1:1276)) ≈ [0; 0:1275; 1275] atol = 1e-12 rtol = 1e-12
-    @test signrankinvlogcdf.(50, signranklogcdf.(50, -1:1276)) ≈ [NaN; 0:1275; 1275] nans = true atol = 1e-12 rtol = 1e-12
-    @test signrankinvlogccdf.(50, signranklogccdf.(50, -1:1276)) ≈ [0; 0:1274; NaN; NaN] nans = true atol = 1e-12 rtol = 1e-12
-
+    @test signrankinvcdf.(50, signrankcdf.(50, -1:1276)) == [0; 0:1275; 1275]
+    @test signrankinvccdf.(50, signrankccdf.(50, -1:1276)) == [0; 0:1275; 1275]
+    @test signrankinvlogcdf.(50, signranklogcdf.(50, 0:1276)) == [0:1275; 1275]
+    @test isnan(signrankinvlogcdf.(50, signranklogcdf(500, -1)))
+    @test signrankinvlogccdf.(50, signranklogccdf.(50, -1:1274)) == [0; 0:1274]
+    @test isnan(signrankinvlogccdf.(50, signranklogccdf.(50, 1275)))
+    @test isnan(signrankinvlogccdf.(50, signranklogccdf.(50, 1276)))
+    
     rmathcomp_tests("srdist", [
         ((1,2), (0.0:0.2:5.0)),
         ((2,2), (0.0:0.2:5.0)),


### PR DESCRIPTION
Implementation of the signrank distribution.
The `cdf` is heavily optimized, since that is what is needed for the popular hypothesis test associated with this distribution.

The testing in this package seems quite involved, I could use some pointers on where to add the tests.

```jl
using StatsFuns
using Rmath

signrankpdf.(-2:12,4)
dsignrank.(-2:12,4,false)

signranklogpdf.(-2:12,4)
dsignrank.(-2:12,4,true)

signrankcdf.(-2:12,4)
psignrank.(-2:12,4,true,false)

signranklogcdf.(-2:12,4)
psignrank.(-2:12,4,true,true)

signrankccdf.(-2:12,4)
psignrank.(-2:12,4,false,false)

signranklogccdf.(-2:12,4)
psignrank.(-2:12,4,false,true)

signrankinvcdf.(-0.01:0.01:1.01,4)
qsignrank.(-0.01:0.01:1.01,4,true,false)
signrankinvcdf.(0.0624,4)
signrankinvcdf.(0.0625,4)
signrankinvcdf.(0.0626,4)
qsignrank.(0.0624,4,true,false)
qsignrank.(0.0625,4,true,false)
qsignrank.(0.0626,4,true,false)

signrankinvlogcdf.(log.(0.0:0.01:1.01),4)
qsignrank.(log.(0.0:0.01:1.01),4,true,true) # 0.0 does not match, is the R definition correct?
qsignrank.(log(0.0),4,true,true)
qsignrank.(0.0,4,true,false) 
signrankinvlogcdf.(log(0.0624),4)
signrankinvlogcdf.(log(0.0625),4)
signrankinvlogcdf.(log(0.0626),4)
qsignrank.(log(0.0624),4,true,true)
qsignrank.(log(0.0625),4,true,true)
qsignrank.(log(0.0626),4,true,true)


signrankinvccdf.(-0.01:0.01:1.01,4)
qsignrank.(-0.01:0.01:1.01,4,false,false) 
signrankinvccdf.(0.0624,4)
signrankinvccdf.(0.0625,4)
signrankinvccdf.(0.0626,4)
qsignrank.(0.0624,4,false,false)
qsignrank.(0.0625,4,false,false)
qsignrank.(0.0626,4,false,false)

signrankinvlogccdf.(log.(0.0:0.01:1.01),4)
qsignrank.(log.(0.0:0.01:1.01),4,false,true) # 0.0 does not match
signrankinvlogccdf.(log(0.0624),4)
signrankinvlogccdf.(log(0.0625),4)
signrankinvlogccdf.(log(0.0626),4)
qsignrank.(log(0.0624),4,false,true)
qsignrank.(log(0.0625),4,false,true)
qsignrank.(log(0.0626),4,false,true)

```
