### PR TITLE
Add downstream tests of HypothesisTests

### DIFF
--- a/.github/workflows/IntegrationTest.yml
+++ b/.github/workflows/IntegrationTest.yml
@@ -43,7 +43,7 @@ jobs:
             Pkg.develop(PackageSpec(path="."))  # resolver may fail with main deps
             Pkg.add("${{ matrix.package }}")
             Pkg.update()
-            Pkg.test()  # resolver may fail with test time deps
+            Pkg.test("${{ matrix.package }}") # resolver may fail with test time deps
           catch err
             err isa Pkg.Resolve.ResolverError || rethrow()
             # If we can't resolve that means this is incompatible by SemVer and this is fine

--- a/.github/workflows/IntegrationTest.yml
+++ b/.github/workflows/IntegrationTest.yml
@@ -33,6 +33,7 @@ jobs:
       - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.julia-version }}
+      - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-buildpkg@v1
       - name: Load this and run the downstream tests
         shell: julia --color=yes {0}

--- a/.github/workflows/IntegrationTest.yml
+++ b/.github/workflows/IntegrationTest.yml
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   test:
-    name: ${{ matrix.package.repo }}/${{ matrix.package.group }}
+    name: ${{ matrix.package }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -25,27 +25,23 @@ jobs:
         julia-version: [1]
         os: [ubuntu-latest]
         package:
-          - {user: JuliaStats, repo: Distributions.jl}
+          - Distributions
+          - HypothesisTests
 
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.julia-version }}
-          arch: x64
       - uses: julia-actions/julia-buildpkg@v1
-      - name: Clone Downstream
-        uses: actions/checkout@v4
-        with:
-          repository: ${{ matrix.package.user }}/${{ matrix.package.repo }}
-          path: downstream
       - name: Load this and run the downstream tests
-        shell: julia --color=yes --project=downstream {0}
+        shell: julia --color=yes {0}
         run: |
           using Pkg
           try
             # force it to use this PR's version of the package
             Pkg.develop(PackageSpec(path="."))  # resolver may fail with main deps
+            Pkg.add("${{ matrix.package }}")
             Pkg.update()
             Pkg.test()  # resolver may fail with test time deps
           catch err


### PR DESCRIPTION
Now that signrank and wilcox distributions are about to be released, it will become possible to replace the Rmath versions in HypothesisTests with these Julia functions. Hence it might be interesting/more relevant to also run downstream tests with HypothesisTests.

Additionally, due to a discussion with @andreasnoack I started to wonder whether it would be better to run downstream tests with the latest released versions of the downstream packages instead of the development branch. One could argue that downstream packages are responsible for testing their development versions appropriately, and its our main responsibility in StatsFuns to not break user code, ie not break compatibility with existing releases.