### PR TITLE
Require Julia >= 1.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
           - windows-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: julia-actions/setup-julia@v2.4
+      - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
       - uses: julia-actions/cache@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ env:
 
 jobs:
   test:
-    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
+    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -34,14 +34,11 @@ jobs:
           - ubuntu-latest
           - macos-latest
           - windows-latest
-        arch:
-          - x64
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2.4
         with:
           version: ${{ matrix.version }}
-          arch: ${{ matrix.arch }}
       - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1

--- a/Project.toml
+++ b/Project.toml
@@ -3,9 +3,7 @@ uuid = "4c63d2b9-4356-54db-8cca-17b64c39e42c"
 version = "1.3.2"
 
 [deps]
-ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
 HypergeometricFunctions = "34004b35-14d8-5ef3-9330-4cdb6864b03a"
-InverseFunctions = "3587e190-3f89-42d0-90ee-14403ec27112"
 IrrationalConstants = "92d709cd-6900-40b7-9082-c6be49f344b6"
 LogExpFunctions = "2ab3a3ac-af41-5b50-aa03-7779005ae688"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
@@ -29,7 +27,7 @@ LogExpFunctions = "0.3.26"
 Reexport = "1"
 Rmath = "0.6.1, 0.7, 0.8"
 SpecialFunctions = "1.8.4, 2.1.4"
-julia = "1.3"
+julia = "1.10"
 
 [extras]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/StatsFuns.jl
+++ b/src/StatsFuns.jl
@@ -286,9 +286,4 @@ include(joinpath("distrs", "signrank.jl"))
 include(joinpath("distrs", "srdist.jl"))
 include(joinpath("distrs", "wilcox.jl"))
 
-if !isdefined(Base, :get_extension)
-    include("../ext/StatsFunsChainRulesCoreExt.jl")
-    include("../ext/StatsFunsInverseFunctionsExt.jl")
-end
-
 end # module

--- a/test/rmath.jl
+++ b/test/rmath.jl
@@ -5,17 +5,8 @@ using Test
 include("utils.jl")
 
 function check_rmath(fname, statsfun, rmathfun, params, aname, a, isprob, rtol)
-    # HypergeometricFunctions@0.3.18 made some changes that trips inference
-    # on older versions of Julia. Not worth the the time trying to debug/fix
-    # as we might drop support for these version soon so just putting the
-    # inference check behind a VERSION branch
-    if VERSION >= v"1.7"
-        v = @inferred(statsfun(params..., a))
-        rv = @inferred(rmathfun(params..., a))
-    else
-        v = statsfun(params..., a)
-        rv = rmathfun(params..., a)
-    end
+    v = @inferred(statsfun(params..., a))
+    rv = @inferred(rmathfun(params..., a))
     @test v isa float(Base.promote_typeof(params..., a))
     @test rv isa float(Base.promote_typeof(params..., a))
     if isprob


### PR DESCRIPTION
I think it's safe to remove support for Julia < 1.10 by now.