### PR TITLE
Hide formatting commit in git-blame

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# Add Runic formatting
+e9ae0ee56eec19bcfa489b4cc5e136889a26169d


### PR DESCRIPTION
Adds a `.git-blame-ignore-revs` file such that https://github.com/JuliaStats/StatsFuns.jl/commit/e9ae0ee56eec19bcfa489b4cc5e136889a26169d is hidden from git-blame, in the Github web interface and with the corresponding setting also locally, see e.g. https://github.com/fredrikekre/Runic.jl?tab=readme-ov-file#ignore-formatting-commits-in-git-blame.