### PR TITLE
Fix srdist by passing nranges=1 to Rmath.ptukey/qtukey

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "StatsFuns"
 uuid = "4c63d2b9-4356-54db-8cca-17b64c39e42c"
-version = "2.0.0"
+version = "2.0.1"
 
 [deps]
 HypergeometricFunctions = "34004b35-14d8-5ef3-9330-4cdb6864b03a"

--- a/src/distrs/srdist.jl
+++ b/src/distrs/srdist.jl
@@ -1,36 +1,39 @@
 # functions related to studentized range distribution
 
 # Rmath implementations
+# The `1` argument is `nranges` (number of ranges) which `Rmath.ptukey`/`qtukey`
+# default to `1.0` in `kwargs` but is positional in the Julia wrapper. Without
+# it the `lower_tail`/`log_p` Bool flags shift into the `nranges` slot.
 function srdistcdf(k::Real, ν::Real, x::Real)
     T = float(Base.promote_typeof(k, ν, x))
-    return convert(T, Rmath.ptukey(x, k, ν, true, false))
+    return convert(T, Rmath.ptukey(x, k, ν, 1, true, false))
 end
 function srdistccdf(k::Real, ν::Real, x::Real)
     T = float(Base.promote_typeof(k, ν, x))
-    return convert(T, Rmath.ptukey(x, k, ν, false, false))
+    return convert(T, Rmath.ptukey(x, k, ν, 1, false, false))
 end
 function srdistlogcdf(k::Real, ν::Real, x::Real)
     T = float(Base.promote_typeof(k, ν, x))
-    return convert(T, Rmath.ptukey(x, k, ν, true, true))
+    return convert(T, Rmath.ptukey(x, k, ν, 1, true, true))
 end
 function srdistlogccdf(k::Real, ν::Real, x::Real)
     T = float(Base.promote_typeof(k, ν, x))
-    return convert(T, Rmath.ptukey(x, k, ν, false, true))
+    return convert(T, Rmath.ptukey(x, k, ν, 1, false, true))
 end
 
 function srdistinvcdf(k::Real, ν::Real, q::Real)
     T = float(Base.promote_typeof(k, ν, q))
-    return convert(T, Rmath.qtukey(q, k, ν, true, false))
+    return convert(T, Rmath.qtukey(q, k, ν, 1, true, false))
 end
 function srdistinvccdf(k::Real, ν::Real, q::Real)
     T = float(Base.promote_typeof(k, ν, q))
-    return convert(T, Rmath.qtukey(q, k, ν, false, false))
+    return convert(T, Rmath.qtukey(q, k, ν, 1, false, false))
 end
 function srdistinvlogcdf(k::Real, ν::Real, lq::Real)
     T = float(Base.promote_typeof(k, ν, lq))
-    return convert(T, Rmath.qtukey(lq, k, ν, true, true))
+    return convert(T, Rmath.qtukey(lq, k, ν, 1, true, true))
 end
 function srdistinvlogccdf(k::Real, ν::Real, lq::Real)
     T = float(Base.promote_typeof(k, ν, lq))
-    return convert(T, Rmath.qtukey(lq, k, ν, false, true))
+    return convert(T, Rmath.qtukey(lq, k, ν, 1, false, true))
 end

--- a/test/rmath.jl
+++ b/test/rmath.jl
@@ -26,6 +26,12 @@ function rmathcomp(basename::String, params, X::AbstractArray, rtol = _default_r
         basename
     end
 
+    # Rmath.ptukey / Rmath.qtukey take an extra `nranges` positional argument
+    # (defaulting to 1.0) between the distribution parameters and the
+    # `lower_tail`/`log_p` flags. Inject it explicitly for tukey so the test
+    # lambdas line up with the Rmath C signature.
+    extra_rmath_args = rbasename == "tukey" ? (1,) : ()
+
     if isdefined(Rmath, Symbol(:d, rbasename))
         stats_pdf = getproperty(@__MODULE__, Symbol(basename, :pdf))
         rmath_pdf = let f = getproperty(Rmath, Symbol(:d, rbasename))
@@ -52,32 +58,32 @@ function rmathcomp(basename::String, params, X::AbstractArray, rtol = _default_r
 
     if isdefined(Rmath, Symbol(:p, rbasename))
         stats_cdf = getproperty(@__MODULE__, Symbol(basename, :cdf))
-        rmath_cdf = let f = getproperty(Rmath, Symbol(:p, rbasename))
-            (a, params...) -> f(a, params..., true, false)
+        rmath_cdf = let f = getproperty(Rmath, Symbol(:p, rbasename)), extra = extra_rmath_args
+            (a, params...) -> f(a, params..., extra..., true, false)
         end
         @testset "cdf with x=$x" for x in X
             check_rmath(stats_cdf, rmath_cdf, params, x, true, rtol)
         end
 
         stats_ccdf = getproperty(@__MODULE__, Symbol(basename, :ccdf))
-        rmath_ccdf = let f = getproperty(Rmath, Symbol(:p, rbasename))
-            (a, params...) -> f(a, params..., false, false)
+        rmath_ccdf = let f = getproperty(Rmath, Symbol(:p, rbasename)), extra = extra_rmath_args
+            (a, params...) -> f(a, params..., extra..., false, false)
         end
         @testset "ccdf with x=$x" for x in X
             check_rmath(stats_ccdf, rmath_ccdf, params, x, true, rtol)
         end
 
         stats_logcdf = getproperty(@__MODULE__, Symbol(basename, :logcdf))
-        rmath_logcdf = let f = getproperty(Rmath, Symbol(:p, rbasename))
-            (a, params...) -> f(a, params..., true, true)
+        rmath_logcdf = let f = getproperty(Rmath, Symbol(:p, rbasename)), extra = extra_rmath_args
+            (a, params...) -> f(a, params..., extra..., true, true)
         end
         @testset "logcdf with x=$x" for x in X
             check_rmath(stats_logcdf, rmath_logcdf, params, x, false, rtol)
         end
 
         stats_logccdf = getproperty(@__MODULE__, Symbol(basename, :logccdf))
-        rmath_logccdf = let f = getproperty(Rmath, Symbol(:p, rbasename))
-            (a, params...) -> f(a, params..., false, true)
+        rmath_logccdf = let f = getproperty(Rmath, Symbol(:p, rbasename)), extra = extra_rmath_args
+            (a, params...) -> f(a, params..., extra..., false, true)
         end
         @testset "logccdf with x=$x" for x in X
             check_rmath(stats_logccdf, rmath_logccdf, params, x, false, rtol)
@@ -97,8 +103,8 @@ function rmathcomp(basename::String, params, X::AbstractArray, rtol = _default_r
         test_inv = (basename != "signrank" && basename != "wilcox") || !Sys.islinux()
         if isdefined(Rmath, Symbol(:q, rbasename)) && test_inv
             stats_invcdf = getproperty(@__MODULE__, Symbol(basename, :invcdf))
-            rmath_invcdf = let f = getproperty(Rmath, Symbol(:q, rbasename))
-                (a, params...) -> f(a, params..., true, false)
+            rmath_invcdf = let f = getproperty(Rmath, Symbol(:q, rbasename)), extra = extra_rmath_args
+                (a, params...) -> f(a, params..., extra..., true, false)
             end
             p = rmath_cdf.(X, params...)
             @testset "invcdf with q=$_p" for _p in p
@@ -106,8 +112,8 @@ function rmathcomp(basename::String, params, X::AbstractArray, rtol = _default_r
             end
 
             stats_invccdf = getproperty(@__MODULE__, Symbol(basename, :invccdf))
-            rmath_invccdf = let f = getproperty(Rmath, Symbol(:q, rbasename))
-                (a, params...) -> f(a, params..., false, false)
+            rmath_invccdf = let f = getproperty(Rmath, Symbol(:q, rbasename)), extra = extra_rmath_args
+                (a, params...) -> f(a, params..., extra..., false, false)
             end
             cp = rmath_ccdf.(X, params...)
             @testset "invccdf with q=$_p" for _p in cp
@@ -115,8 +121,8 @@ function rmathcomp(basename::String, params, X::AbstractArray, rtol = _default_r
             end
 
             stats_invlogcdf = getproperty(@__MODULE__, Symbol(basename, :invlogcdf))
-            rmath_invlogcdf = let f = getproperty(Rmath, Symbol(:q, rbasename))
-                (a, params...) -> f(a, params..., true, true)
+            rmath_invlogcdf = let f = getproperty(Rmath, Symbol(:q, rbasename)), extra = extra_rmath_args
+                (a, params...) -> f(a, params..., extra..., true, true)
             end
             lp = rmath_logcdf.(X, params...)
             @testset "invlogcdf with log(q)=$_p" for _p in lp
@@ -124,8 +130,8 @@ function rmathcomp(basename::String, params, X::AbstractArray, rtol = _default_r
             end
 
             stats_invlogccdf = getproperty(@__MODULE__, Symbol(basename, :invlogccdf))
-            rmath_invlogccdf = let f = getproperty(Rmath, Symbol(:q, rbasename))
-                (a, params...) -> f(a, params..., false, true)
+            rmath_invlogccdf = let f = getproperty(Rmath, Symbol(:q, rbasename)), extra = extra_rmath_args
+                (a, params...) -> f(a, params..., extra..., false, true)
             end
             lcp = rmath_logccdf.(X, params...)
             @testset "invlogccdf with log(q)=$_p" for _p in lcp
@@ -474,6 +480,19 @@ end
     rx = srdistinvcdf(10, 5, q)
     rtol = 100eps(1.0)
     @test_broken x ≈ rx atol = rtol rtol = rtol nans = true
+
+    # `nranges=1` must be passed to Rmath.ptukey/qtukey; without it the Bool
+    # flags shift into the `nranges` slot and CDF↔CCDF invert.
+    @testset "srdist boundary behaviour" begin
+        @test iszero(srdistcdf(2.0, 2.0, 0.0))
+        @test isone(srdistccdf(2.0, 2.0, 0.0))
+        @test srdistlogcdf(2.0, 2.0, 0.0) == -Inf
+        @test iszero(srdistlogccdf(2.0, 2.0, 0.0))
+        @test isone(srdistcdf(2.0, 2.0, Inf))
+        @test iszero(srdistccdf(2.0, 2.0, Inf))
+        @test iszero(srdistlogcdf(2.0, 2.0, Inf))
+        @test srdistlogccdf(2.0, 2.0, Inf) == -Inf
+    end
 
     # Test values outside of the support
     rmathcomp_tests(


### PR DESCRIPTION
## Summary

The inlining of the `RFunctions` macro in #188 dropped the special-case that
appended a literal `1` for `:tukey`, so the `lower_tail`/`log_p` `Bool` flags
shifted into the `nranges` positional slot of `Rmath.ptukey`/`qtukey`. As a
result, `srdistcdf` ↔ `srdistccdf` are silently inverted on `v2.0.0` and the
inverse CDF functions also return wrong values. For example:

```julia
julia> using StatsFuns

julia> srdistcdf(2.0, 2.0, 0.0)         # should be 0
1.0
```

Restore the missing `1` argument explicitly in all 8 `Rmath.ptukey`/`qtukey`
calls.

## Why the existing tests didn't catch it

The `rmathcomp` harness compared StatsFuns' buggy `srdistcdf` against an
equally buggy direct `Rmath.ptukey(..., true, false)` call, so the test
agreed with itself. Fix the harness to inject `nranges=1` for tukey when
building the Rmath-side lambdas, and add a strict-equality
`@testset "srdist boundary behaviour"` covering `x = 0` and `x = Inf` for
all four cdf-like functions.

## Test plan

- [x] `Pkg.test()` passes locally (full suite)
- [x] New `srdist boundary behaviour` testset passes (8 strict `==` assertions)
- [x] Verified Distributions.jl's `StudentizedRange` and
  `Truncated{StudentizedRange}` test failures on JuliaStats/Distributions.jl#2062
  go away when this branch is dev'd in

🤖 Generated with [Claude Code](https://claude.com/claude-code)