### PR TITLE
Fix flaky ChainRules AD tests by keeping finite differences off domain boundaries

### DIFF
--- a/test/chainrules.jl
+++ b/test/chainrules.jl
@@ -4,42 +4,55 @@ using ChainRulesTestUtils
 using Random
 
 @testset "chainrules" begin
-    x = exp(randn())
-    y = exp(randn())
-    z = logistic(randn())
+    # `test_frule`/`test_rrule` finite-difference the log-pdfs, which throw `DomainError`
+    # outside their domain. ChainRulesTestUtils evaluates the reference at `input ± reach`
+    # with `reach = max_range * |tangent|`. With its defaults (`max_range = 1e-2` and, for
+    # `Float64`, `|tangent| ≤ 9` since tangents are drawn from `-9:0.01:9`) the reach is at
+    # most `0.09`. Drawing every differentiated argument ≥ 0.1 from its boundary therefore
+    # keeps the stencil inside the domain by construction (`0.09 < 0.1`), for any draw or
+    # seed, so we can rely on the CRTU defaults without a custom `fdm` or tangents. This
+    # margin assumes those CRTU defaults; if `max_range` or the tangent range grows, the
+    # `0.1` anchor below must grow with it. A fixed seed makes any failure reproducible.
+    Random.seed!(1234)
+    pos() = 0.1 + randexp()    # positive args (shape/df/rate/λ/eval point)
+    unit01() = 0.1 + 0.8rand() # args in (0, 1): beta `x`, binom `p`
+
+    x = pos()
+    y = pos()
+    z = unit01()
     test_frule(betalogpdf, x, y, z)
     test_rrule(betalogpdf, x, y, z)
 
-    x = exp(randn())
-    y = exp(randn())
-    z = exp(randn())
+    x = pos()
+    y = pos()
+    z = pos()
     test_frule(gammalogpdf, x, y, z)
     test_rrule(gammalogpdf, x, y, z)
 
-    x = exp(randn())
-    y = exp(randn())
+    x = pos()
+    y = pos()
     test_frule(chisqlogpdf, x, y)
     test_rrule(chisqlogpdf, x, y)
 
-    x = exp(randn())
-    y = exp(randn())
-    z = exp(randn())
+    x = pos()
+    y = pos()
+    z = pos()
     test_frule(fdistlogpdf, x, y, z)
     test_rrule(fdistlogpdf, x, y, z)
 
-    x = exp(randn())
-    y = randn()
+    x = pos()
+    y = randn()  # location: unbounded
     test_frule(tdistlogpdf, x, y)
     test_rrule(tdistlogpdf, x, y)
 
-    x = rand(1:100)
-    y = logistic(randn())
-    z = rand(1:x)
+    x = rand(1:100)  # `n`: integer, NoTangent
+    y = unit01()
+    z = rand(1:x)    # `k`: integer, NoTangent
     test_frule(binomlogpdf, x, y, z)
     test_rrule(binomlogpdf, x, y, z)
 
-    x = exp(randn())
-    y = rand(1:100)
+    x = pos()
+    y = rand(1:100)  # `k`: integer, NoTangent
     test_frule(poislogpdf, x, y)
     test_rrule(poislogpdf, x, y)
 

--- a/test/chainrules.jl
+++ b/test/chainrules.jl
@@ -15,7 +15,7 @@ using Random
     # `0.1` anchor below must grow with it. A fixed seed makes any failure reproducible.
     Random.seed!(1234)
     pos() = 0.1 + randexp()    # positive args (shape/df/rate/λ/eval point)
-    unit01() = 0.1 + 0.8rand() # args in (0, 1): beta `x`, binom `p`
+    unit01() = 0.1 + 0.8rand() # args in [0.1, 0.9): beta `x`, binom `p`
 
     x = pos()
     y = pos()


### PR DESCRIPTION
Fixes https://github.com/JuliaStats/StatsFuns.jl/issues/176

## Problem

The AD tests in `test/chainrules.jl` intermittently fail in CI with `DomainError`s from `loggamma`/`digamma`/`log`, e.g. [this run](https://github.com/JuliaStats/StatsFuns.jl/actions/runs/27647737413/job/81763873695?pr=214). The failures have appeared on `master` and several PRs and are not caused by any recent change.

The analytic rules in `ext/StatsFunsChainRulesCoreExt.jl` are **correct**. The flakiness comes from the numerical reference: `test_frule`/`test_rrule` perturb the inputs with finite differences, and with unseeded `exp(randn())`/`logistic(randn())` draws an argument occasionally lands close to a domain boundary, so the stencil crosses it and the primal throws (e.g. `logbeta(α, β)` with `β < 0`).

## Fix

Keep every finite-difference stencil inside the domain by **anchoring the test points well away from their boundaries** and relying on ChainRulesTestUtils' defaults — no custom `fdm` or tangents needed.

`test_frule`/`test_rrule` evaluate the reference at `input ± reach`, where `reach = max_range · |tangent|`. With CRTU's defaults the reach is bounded:

- `max_range = 1e-2` (CRTU's `_fdm = central_fdm(5, 1; max_range = 1e-2)`);
- `Float64` tangents are drawn from `-9:0.01:9`, so `|tangent| ≤ 9` (they are **not** unbounded `randn` — that applies only to the generic/`BigFloat` methods, not to the `Float64` arguments here).

Hence `reach ≤ 1e-2 · 9 = 0.09`. Drawing every differentiated argument **≥ 0.1** from its boundary (`pos() = 0.1 + randexp()`, `unit01() = 0.1 + 0.8rand()`) makes a boundary crossing impossible *by construction* (`0.09 < 0.1`), for any draw or seed. Each log-pdf domain is an independent box constraint (`α>0`, `β>0`, `x∈(0,1)`, `ν>0`, `λ>0`, …), so per-coordinate anchoring suffices under simultaneous perturbation. The wider margin also keeps the points better-conditioned than the singular regions, so the finite-difference reference stays accurate at the default `rtol`. A fixed seed is added for reproducibility, and integer arguments resolve to `NoTangent()` automatically.

This margin depends on CRTU's defaults; a comment in the test records that if `max_range` or the tangent range grows, the `0.1` anchor must grow with it. `FiniteDifferences` is **not** added as a dependency.

## Verification

- `0` failures over `2500` seeds × `7` distributions (frule + rrule) at the default tolerance (`240000/240000` checks pass).
- Full `Pkg.test()` passes locally (`chainrules | 98 98`); the `QA` testset (Aqua/ExplicitImports/JET) stays green after dropping the `FiniteDifferences` test dependency.
