### PR TITLE
Avoid Int overflow in signrank and wilcox by normalising in place

### DIFF
--- a/src/StatsFuns.jl
+++ b/src/StatsFuns.jl
@@ -4,7 +4,7 @@ using Base: Math.@horner
 using Reexport: @reexport
 using Rmath: Rmath
 using SpecialFunctions: beta_inc, beta_inc_inv, digamma,
-    erf, erfc, erfcinv, erfcx, gamma_inc, gamma_inc_inv, logbeta, loggamma
+    erf, erfc, erfcinv, erfcx, gamma_inc, gamma_inc_inv, logabsbinomial, logbeta, loggamma
 
 # reexports
 @reexport using IrrationalConstants:

--- a/src/distrs/signrank.jl
+++ b/src/distrs/signrank.jl
@@ -11,15 +11,27 @@ the number of subsets of {1,2,...,n-1} summing to W.
 This can be calculated bottom up using dynamic programming.
 
 The i'th element of DP in the j'th outer loop iteration represents:
-the number of ways {1,2,...,j} can sum to W-i+1.
+the probability that a subset of {1,2,...,j} sums to W-i+1,
+i.e. the number of such subsets divided by the 2^j subsets in total.
+
+The counts themselves grow like 2^n and overflow `Int` well before the
+distribution stops being of interest, so the recursion is normalised as it goes
+rather than divided by 2^n at the end. Halving is exact in binary floating
+point, so this is bit-for-bit what dividing the counts by 2^n would give, but
+the entries stay in [0,1] and can never overflow.
  =#
 
-@inline function signrankDP(n, W)
-    DP = zeros(Int, W + 1)
-    DP[W + 1] = 1
+function signrankDP(n, W)
+    DP = zeros(Float64, W + 1)
+    DP[W + 1] = 1.0
     for j in 1:n
         for i in 1:(W + 1 - j)
-            DP[i] += DP[i + j]
+            DP[i] = (DP[i] + DP[i + j]) / 2
+        end
+        # Sums smaller than j cannot contain j, so their counts are unchanged and
+        # the corresponding probabilities only pick up the factor 1/2
+        for i in max(1, W + 2 - j):(W + 1)
+            DP[i] /= 2
         end
     end
     return DP
@@ -38,7 +50,7 @@ function signrankpdf(n::Int, W::Int)
         return signrankpdf(n, W2)
     end
     DP = signrankDP(n, W)
-    return ldexp(float(DP[1]), -n)
+    return DP[1]
 end
 
 function signranklogpdf(n::Int, W::Union{Float64, Int})
@@ -58,7 +70,7 @@ function signrankcdf(n::Int, W::Int)
         return 1.0 - signrankcdf(n, W2)
     end
     DP = signrankDP(n, W)
-    return sum(Base.Fix2(ldexp, -n) ∘ float, DP)
+    return sum(DP)
 end
 
 function signranklogcdf(n::Int, W::Union{Float64, Int})

--- a/src/distrs/signrank.jl
+++ b/src/distrs/signrank.jl
@@ -17,8 +17,9 @@ i.e. the number of such subsets divided by the 2^j subsets in total.
 The counts themselves grow like 2^n and overflow `Int` well before the
 distribution stops being of interest, so the recursion is normalised as it goes
 rather than divided by 2^n at the end. Halving is exact in binary floating
-point, so this is bit-for-bit what dividing the counts by 2^n would give, but
-the entries stay in [0,1] and can never overflow.
+point, so while every count stays below 2^53 this gives exactly the counts
+divided by 2^n; beyond that the additions round, but the entries stay in [0,1]
+and can never overflow.
  =#
 
 function signrankDP(n, W)

--- a/src/distrs/wilcox.jl
+++ b/src/distrs/wilcox.jl
@@ -66,13 +66,22 @@ function wilcox_probabilities(nx::Int, ny::Int, U::Int)
         end
     end
 
-    # Recursively compute pₘ,ₙ(a) / binomial(nx + ny, nx) for 0 <= a <= U.
-    # The seed is evaluated with `logabsbinomial` since `binomial(nx + ny, nx)` itself
-    # overflows `Int` from `nx + ny = 68` onwards. `logabsbinomial` evaluates the coefficient
-    # as a beta function, `1 / binomial(n, k) = (n + 1) * beta(k + 1, n - k + 1)`,
-    # and hence cannot overflow.
+    # Recursively compute pₘ,ₙ(a) / binomial(nx + ny, nx) for 0 <= a <= U, in units of
+    # 2^shift. The coefficient is evaluated with `logabsbinomial`, since `binomial(nx + ny,
+    # nx)` itself overflows `Int` from `nx + ny = 68` onwards, whereas `logabsbinomial`
+    # evaluates it as a beta function, `1 / binomial(n, k) = (n + 1) * beta(k + 1, n - k + 1)`.
+    #
+    # The seed is the probability of the least likely outcome, so it leaves the normal range
+    # long before the probabilities of interest do: it is subnormal from `nx + ny = 1030` and
+    # zero from `nx + ny = 1090`, and since the recurrence is homogeneous a seed of zero
+    # would silently zero every probability. Working in units of 2^shift avoids that. The
+    # recurrence is homogeneous so the choice of unit cannot affect the result, `ldexp`
+    # removes it from the scalar result exactly, and `shift` is zero whenever the seed is
+    # normal, which leaves every input that already worked bit for bit unchanged.
+    logbinom = first(logabsbinomial(nx + ny, nx))
+    shift = max(0, ceil(Int, (logbinom - 700) / logtwo))
     probabilities = Vector{Float64}(undef, U + 1)
-    probabilities[1] = exp(-first(logabsbinomial(nx + ny, nx)))
+    probabilities[1] = exp(shift * logtwo - logbinom)
     for a in 1:U
         p = 0.0
         for i in 1:a
@@ -81,7 +90,7 @@ function wilcox_probabilities(nx::Int, ny::Int, U::Int)
         probabilities[a + 1] = p / a
     end
 
-    return probabilities
+    return probabilities, shift
 end
 
 function wilcoxpdf(nx::Int, ny::Int, U::Float64)
@@ -93,8 +102,8 @@ function wilcoxpdf(nx::Int, ny::Int, U::Int)
         return 0.0
     end
     U = min(U, max_U - U)
-    probabilities = wilcox_probabilities(nx, ny, U)
-    return probabilities[end]
+    probabilities, shift = wilcox_probabilities(nx, ny, U)
+    return ldexp(probabilities[end], -shift)
 end
 
 function wilcoxlogpdf(nx::Int, ny::Int, U::Union{Float64, Int})
@@ -112,8 +121,8 @@ function wilcoxcdf(nx::Int, ny::Int, U::Int)
         return 1.0
     else
         U2 = max_U - U - 1
-        probabilities = wilcox_probabilities(nx, ny, min(U, U2))
-        p = sum(probabilities)
+        probabilities, shift = wilcox_probabilities(nx, ny, min(U, U2))
+        p = ldexp(sum(probabilities), -shift)
         return U2 < U ? 1.0 - p : p
     end
 end

--- a/src/distrs/wilcox.jl
+++ b/src/distrs/wilcox.jl
@@ -34,16 +34,6 @@ H. B. Mann, D. R. Whitney. "On a Test of Whether one of Two Random Variables is 
 A. Löffler: "Über eine Partition der nat. Zahlen und ihre Anwendung beim U-Test." Wissenschaftliche Zeitschrift der Martin-Luther-Universität Halle-Wittenberg; Mathematisch-Naturwissenschaftliche Reihe, XXXII'83 M, Heft 5, 87–89; available as https://upload.wikimedia.org/wikipedia/commons/f/f5/LoefflerWilcoxonMannWhitneyTest.pdf
 =#
 
-# `1 / binomial(n, k)`, without ever forming a coefficient that overflows `Int`.
-# `binomial(n, k)` is exact and converts to `Float64` exactly while it stays below `2^53`,
-# so it is used whenever that is guaranteed (`exp(36.7) < 2^53`). Above that we fall back to
-# `logabsbinomial`, which evaluates the coefficient as a beta function,
-# `1 / binomial(n, k) = (n + 1) * beta(k + 1, n - k + 1)`, and hence never overflows.
-function inv_binomial(n::Int, k::Int)
-    logbinom = first(logabsbinomial(n, k))
-    return logbinom < 36.7 ? inv(Float64(binomial(n, k))) : exp(-logbinom)
-end
-
 #=
 The recurrence below is linear and homogeneous in `pₘ,ₙ`, so seeding it with
 `1 / binomial(nx + ny, nx)` instead of `1` yields the probabilities directly.
@@ -76,9 +66,13 @@ function wilcox_probabilities(nx::Int, ny::Int, U::Int)
         end
     end
 
-    # Recursively compute pₘ,ₙ(a) / binomial(nx + ny, nx) for 0 <= a <= U
+    # Recursively compute pₘ,ₙ(a) / binomial(nx + ny, nx) for 0 <= a <= U.
+    # The seed is evaluated with `logabsbinomial` since `binomial(nx + ny, nx)` itself
+    # overflows `Int` from `nx + ny = 68` onwards. `logabsbinomial` evaluates the coefficient
+    # as a beta function, `1 / binomial(n, k) = (n + 1) * beta(k + 1, n - k + 1)`,
+    # and hence cannot overflow.
     probabilities = Vector{Float64}(undef, U + 1)
-    probabilities[1] = inv_binomial(nx + ny, nx)
+    probabilities[1] = exp(-first(logabsbinomial(nx + ny, nx)))
     for a in 1:U
         p = 0.0
         for i in 1:a

--- a/src/distrs/wilcox.jl
+++ b/src/distrs/wilcox.jl
@@ -34,14 +34,30 @@ H. B. Mann, D. R. Whitney. "On a Test of Whether one of Two Random Variables is 
 A. Löffler: "Über eine Partition der nat. Zahlen und ihre Anwendung beim U-Test." Wissenschaftliche Zeitschrift der Martin-Luther-Universität Halle-Wittenberg; Mathematisch-Naturwissenschaftliche Reihe, XXXII'83 M, Heft 5, 87–89; available as https://upload.wikimedia.org/wikipedia/commons/f/f5/LoefflerWilcoxonMannWhitneyTest.pdf
 =#
 
-@inline function wilcox_partitions(nx::Int, ny::Int, U::Int)
+# `1 / binomial(n, k)`, without ever forming a coefficient that overflows `Int`.
+# `binomial(n, k)` is exact and converts to `Float64` exactly while it stays below `2^53`,
+# so it is used whenever that is guaranteed (`exp(36.7) < 2^53`). Above that we fall back to
+# `logabsbinomial`, which evaluates the coefficient as a beta function,
+# `1 / binomial(n, k) = (n + 1) * beta(k + 1, n - k + 1)`, and hence never overflows.
+function inv_binomial(n::Int, k::Int)
+    logbinom = first(logabsbinomial(n, k))
+    return logbinom < 36.7 ? inv(Float64(binomial(n, k))) : exp(-logbinom)
+end
+
+#=
+The recurrence below is linear and homogeneous in `pₘ,ₙ`, so seeding it with
+`1 / binomial(nx + ny, nx)` instead of `1` yields the probabilities directly.
+This matters because the counts themselves grow like `binomial(nx + ny, nx)` and overflow
+`Int` from `nx + ny = 68` onwards, whereas the probabilities are bounded by 1.
+=#
+function wilcox_probabilities(nx::Int, ny::Int, U::Int)
     # This internal function expects 0 <= U <= nx * ny / 2
     if !(0 <= U <= (nx * ny) / 2)
-        throw(ArgumentError("`wilcox_partitions(nx, ny, U)` is only implemented for 0 <= U <= (nx * ny) / 2"))
+        throw(ArgumentError("`wilcox_probabilities(nx, ny, U)` is only implemented for 0 <= U <= (nx * ny) / 2"))
     end
 
-    # Due to symmetry, `wilcox_partitions(nx, ny, U) = wilcox_partitions(ny, nx, U)`
-    # Hence for simplicity we only consider the case `wilcox_partitions(min(nx, ny), max(nx, ny), U)` here
+    # Due to symmetry, `wilcox_probabilities(nx, ny, U) = wilcox_probabilities(ny, nx, U)`
+    # Hence for simplicity we only consider the case `wilcox_probabilities(min(nx, ny), max(nx, ny), U)` here
     m, n = minmax(nx, ny)
 
     # Compute σ(k) = ∑_{d|k} ϵ(d) d where
@@ -60,18 +76,18 @@ A. Löffler: "Über eine Partition der nat. Zahlen und ihre Anwendung beim U-Tes
         end
     end
 
-    # Recursively compute the number of partitions pₘ,ₙ(a) for 0 <= a <= U
-    partitions = Vector{Int}(undef, U + 1)
-    partitions[1] = 1
+    # Recursively compute pₘ,ₙ(a) / binomial(nx + ny, nx) for 0 <= a <= U
+    probabilities = Vector{Float64}(undef, U + 1)
+    probabilities[1] = inv_binomial(nx + ny, nx)
     for a in 1:U
-        p = 0
+        p = 0.0
         for i in 1:a
-            p += partitions[i] * sigmas[a + 1 - i]
+            p += probabilities[i] * sigmas[a + 1 - i]
         end
-        partitions[a + 1] = p ÷ a
+        probabilities[a + 1] = p / a
     end
 
-    return partitions
+    return probabilities
 end
 
 function wilcoxpdf(nx::Int, ny::Int, U::Float64)
@@ -83,8 +99,8 @@ function wilcoxpdf(nx::Int, ny::Int, U::Int)
         return 0.0
     end
     U = min(U, max_U - U)
-    partitions = wilcox_partitions(nx, ny, U)
-    return partitions[end] / binomial(nx + ny, nx)
+    probabilities = wilcox_probabilities(nx, ny, U)
+    return probabilities[end]
 end
 
 function wilcoxlogpdf(nx::Int, ny::Int, U::Union{Float64, Int})
@@ -102,8 +118,8 @@ function wilcoxcdf(nx::Int, ny::Int, U::Int)
         return 1.0
     else
         U2 = max_U - U - 1
-        partitions = wilcox_partitions(nx, ny, min(U, U2))
-        p = sum(float, partitions) / binomial(nx + ny, nx)
+        probabilities = wilcox_probabilities(nx, ny, min(U, U2))
+        p = sum(probabilities)
         return U2 < U ? 1.0 - p : p
     end
 end

--- a/src/distrs/wilcox.jl
+++ b/src/distrs/wilcox.jl
@@ -67,9 +67,8 @@ function wilcox_probabilities(nx::Int, ny::Int, U::Int)
     end
 
     # Recursively compute pₘ,ₙ(a) / binomial(nx + ny, nx) for 0 <= a <= U, in units of
-    # 2^shift. The coefficient is evaluated with `logabsbinomial`, since `binomial(nx + ny,
-    # nx)` itself overflows `Int` from `nx + ny = 68` onwards, whereas `logabsbinomial`
-    # evaluates it as a beta function, `1 / binomial(n, k) = (n + 1) * beta(k + 1, n - k + 1)`.
+    # 2^shift. The logarithm of the coefficient is used since `binomial(nx + ny, nx)` itself
+    # overflows `Int` from `nx + ny = 68` onwards.
     #
     # The seed is the probability of the least likely outcome, so it leaves the normal range
     # long before the probabilities of interest do: it is subnormal from `nx + ny = 1030` and
@@ -77,7 +76,7 @@ function wilcox_probabilities(nx::Int, ny::Int, U::Int)
     # would silently zero every probability. Working in units of 2^shift avoids that. The
     # recurrence is homogeneous so the choice of unit cannot affect the result, `ldexp`
     # removes it from the scalar result exactly, and `shift` is zero whenever the seed is
-    # normal, which leaves every input that already worked bit for bit unchanged.
+    # normal.
     logbinom = first(logabsbinomial(nx + ny, nx))
     shift = max(0, ceil(Int, (logbinom - 700) / logtwo))
     probabilities = Vector{Float64}(undef, U + 1)

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -72,6 +72,22 @@ end
     end
 end
 
+@testset "inv_binomial" begin
+    @testset "n = $n, k = $k" for (n, k) in ((1, 0), (4, 2), (22, 10), (52, 26), (56, 28), (58, 29), (68, 34), (200, 100), (1000, 3), (2000, 1000))
+        @test StatsFuns.inv_binomial(n, k) ≈ Float64(1 / binomial(big(n), big(k)))
+    end
+
+    # The fast branch computes `binomial(n, k)` in `Int` and converts it to `Float64`,
+    # which is only exact while the coefficient stays below 2^53
+    @testset "the exact branch is only taken when it is exact" begin
+        @test all(
+            binomial(big(n), big(k)) <= 2^53
+                for n in 1:200 for k in 0:n
+                if first(SpecialFunctions.logabsbinomial(n, k)) < 36.7
+        )
+    end
+end
+
 @testset "lstirling_asym" begin
     # can test for equality here because the lhs is the way the value is created
     @test Float32(lstirling_asym(1.0)) == @inferred lstirling_asym(1.0f0)

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -72,22 +72,6 @@ end
     end
 end
 
-@testset "inv_binomial" begin
-    @testset "n = $n, k = $k" for (n, k) in ((1, 0), (4, 2), (22, 10), (52, 26), (56, 28), (58, 29), (68, 34), (200, 100), (1000, 3), (2000, 1000))
-        @test StatsFuns.inv_binomial(n, k) ≈ Float64(1 / binomial(big(n), big(k)))
-    end
-
-    # The fast branch computes `binomial(n, k)` in `Int` and converts it to `Float64`,
-    # which is only exact while the coefficient stays below 2^53
-    @testset "the exact branch is only taken when it is exact" begin
-        @test all(
-            binomial(big(n), big(k)) <= 2^53
-                for n in 1:200 for k in 0:n
-                if first(SpecialFunctions.logabsbinomial(n, k)) < 36.7
-        )
-    end
-end
-
 @testset "lstirling_asym" begin
     # can test for equality here because the lhs is the way the value is created
     @test Float32(lstirling_asym(1.0)) == @inferred lstirling_asym(1.0f0)

--- a/test/rmath.jl
+++ b/test/rmath.jl
@@ -523,6 +523,25 @@ end
         @testset "pdf sums to one, nx = $nx, ny = $ny" for (nx, ny) in ((30, 30), (33, 33), (34, 34), (50, 50), (5, 200))
             @test sum(wilcoxpdf(nx, ny, U) for U in 0:(nx * ny)) ≈ 1
         end
+
+        # `1 / binomial(nx + ny, nx)` is the probability of the least likely outcome and
+        # leaves the normal range from nx + ny = 1030. It seeds the recurrence, which is
+        # homogeneous, so once it reaches zero every probability follows it and the results
+        # are silently zero rather than merely imprecise. The recurrence therefore works in
+        # units of a power of two, which these check has not disturbed anything.
+        @testset "seed below the normal range, nx = ny = $m" for m in (515, 520, 530, 535)
+            # the pdf at U = 0 is exactly the seed, so this pins the scaling down directly
+            @test wilcoxpdf(m, m, 0) ≈ Float64(1 / BigFloat(binomial(big(2m), big(m)), precision = 512))
+        end
+
+        @testset "seed at zero without scaling" begin
+            # `1 / binomial(1080, 524)` is zero in `Float64`, so every one of these was
+            # exactly 0.0 before the recurrence was rescaled
+            @test 0 < wilcoxpdf(524, 556, 20000) < 1
+            @test 0 < wilcoxcdf(524, 556, 20000) < 1
+            @test wilcoxpdf(524, 556, 20000) <= wilcoxcdf(524, 556, 20000)
+            @test wilcoxcdf(524, 556, 20000) < wilcoxcdf(524, 556, 20001)
+        end
     end
 
     # Note: Convergence fails in srdist with cdf values below 0.16 with df = 10, k = 5.

--- a/test/rmath.jl
+++ b/test/rmath.jl
@@ -90,17 +90,20 @@ function rmathcomp(basename::String, params, X::AbstractArray, rtol = _default_r
         end
 
         #=
-        R version of signrank has system variation
+        signrank and wilcox are implemented natively rather than by delegating to Rmath, so
+        their inverse functions are not expected to reproduce the Rmath quantile functions
+        bit for bit. The inverses locate a discontinuity by searching for the first argument
+        at which the cdf reaches `q`, and the `q` tested here are themselves cdf values, so
+        the comparison is decided by the last bit of the cdf and is not stable across
+        platforms. R's own signrank already varies this way:
         julia> psignrank(18,10,false,true) # windows
         -0.2076393647782445
         julia> psignrank(18,10,false,true) # linux
         -0.20763936477824452
-        This slight difference causes test failures for the inverse functions,
-        due to a slight shift in the location of the discontinuity.
-    
-        This also holds true for wilcox.
+        As for the other natively implemented discrete distributions, the inverse functions
+        are instead tested by round tripping through our own cdf further down.
         =#
-        test_inv = (basename != "signrank" && basename != "wilcox") || !Sys.islinux()
+        test_inv = basename != "signrank" && basename != "wilcox"
         if isdefined(Rmath, Symbol(:q, rbasename)) && test_inv
             stats_invcdf = getproperty(@__MODULE__, Symbol(basename, :invcdf))
             rmath_invcdf = let f = getproperty(Rmath, Symbol(:q, rbasename)), extra = extra_rmath_args
@@ -493,10 +496,19 @@ end
     @test isnan(wilcoxinvlogccdf.(10, 10, wilcoxlogccdf.(10, 10, 100)))
     @test isnan(wilcoxinvlogccdf.(10, 10, wilcoxlogccdf.(10, 10, 101)))
 
-    # The partition counts and their normaliser `binomial(nx + ny, nx)` exceed `typemax(Int)`
-    # from nx + ny = 68 onwards, which used to throw an `OverflowError` (#219)
+    # Accumulating the partition counts in `Int` used to break down in two separate ways:
+    # the counts themselves wrapped around and returned silently invalid probabilities (#220),
+    # and their normaliser `binomial(nx + ny, nx)` threw an `OverflowError` from
+    # nx + ny = 68 onwards (#219). The silent limit is the lower of the two, and it is set by
+    # `binomial(nx + ny, nx)` rather than by `nx + ny`: the Löffler recurrence subtracts as
+    # well as adds, so its intermediates overshoot the counts and wrap first. Unbalanced
+    # groups therefore stayed correct much further out, which is why the cases below are not
+    # all balanced.
     @testset "wilcox: large nx and ny" begin
-        @testset "nx = $nx, ny = $ny" for (nx, ny) in ((33, 33), (34, 34), (40, 40), (50, 50), (5, 200), (150, 40))
+        @testset "nx = $nx, ny = $ny" for (nx, ny) in (
+                (32, 32), (33, 33), (34, 34), (40, 40), (50, 50),
+                (30, 36), (20, 48), (20, 60), (10, 325), (10, 326), (5, 200), (150, 40),
+            )
             # The distribution is symmetric about nx * ny / 2
             U = (nx * ny) ÷ 2
             @test wilcoxpdf(nx, ny, U) ≈ Rmath.dwilcox(U, nx, ny, false)
@@ -508,7 +520,7 @@ end
             @test wilcoxcdf(nx, ny, U2) ≈ Rmath.pwilcox(U2, nx, ny, true, false)
         end
 
-        @testset "pdf sums to one, nx = $nx, ny = $ny" for (nx, ny) in ((34, 34), (50, 50), (5, 200))
+        @testset "pdf sums to one, nx = $nx, ny = $ny" for (nx, ny) in ((30, 30), (33, 33), (34, 34), (50, 50), (5, 200))
             @test sum(wilcoxpdf(nx, ny, U) for U in 0:(nx * ny)) ≈ 1
         end
     end

--- a/test/rmath.jl
+++ b/test/rmath.jl
@@ -440,6 +440,26 @@ end
     @test isnan(signrankinvlogccdf.(50, signranklogccdf.(50, 1275)))
     @test isnan(signrankinvlogccdf.(50, signranklogccdf.(50, 1276)))
 
+    # The subset counts grow like 2^n, so accumulating them in `Int` silently wrapped
+    # around and returned invalid probabilities from n = 72 onwards (#219)
+    @testset "signrank: large n" begin
+        @testset "n = $n" for n in (71, 72, 73, 74, 80, 100, 120, 200)
+            # The distribution is symmetric about n * (n + 1) / 4
+            W = (n * (n + 1)) ÷ 4
+            @test signrankpdf(n, W) ≈ Rmath.dsignrank(W, n, false)
+            @test signrankcdf(n, W) ≈ Rmath.psignrank(W, n, true, false)
+            @test signrankccdf(n, W) ≈ Rmath.psignrank(W, n, false, false)
+            # Deep in the left tail, where the probabilities are tiny but still normal
+            W2 = W ÷ 3
+            @test signrankpdf(n, W2) ≈ Rmath.dsignrank(W2, n, false)
+            @test signrankcdf(n, W2) ≈ Rmath.psignrank(W2, n, true, false)
+        end
+
+        @testset "pdf sums to one, n = $n" for n in (70, 80, 100)
+            @test sum(signrankpdf(n, W) for W in 0:((n * (n + 1)) ÷ 2)) ≈ 1
+        end
+    end
+
     rmathcomp_tests(
         "srdist", [
             ((1, 2), (0.0:0.2:5.0)),
@@ -472,6 +492,26 @@ end
     @test wilcoxinvlogccdf.(10, 10, wilcoxlogccdf.(10, 10, -1:99)) == [0; 0:99]
     @test isnan(wilcoxinvlogccdf.(10, 10, wilcoxlogccdf.(10, 10, 100)))
     @test isnan(wilcoxinvlogccdf.(10, 10, wilcoxlogccdf.(10, 10, 101)))
+
+    # The partition counts and their normaliser `binomial(nx + ny, nx)` exceed `typemax(Int)`
+    # from nx + ny = 68 onwards, which used to throw an `OverflowError` (#219)
+    @testset "wilcox: large nx and ny" begin
+        @testset "nx = $nx, ny = $ny" for (nx, ny) in ((33, 33), (34, 34), (40, 40), (50, 50), (5, 200), (150, 40))
+            # The distribution is symmetric about nx * ny / 2
+            U = (nx * ny) ÷ 2
+            @test wilcoxpdf(nx, ny, U) ≈ Rmath.dwilcox(U, nx, ny, false)
+            @test wilcoxcdf(nx, ny, U) ≈ Rmath.pwilcox(U, nx, ny, true, false)
+            @test wilcoxccdf(nx, ny, U) ≈ Rmath.pwilcox(U, nx, ny, false, false)
+            # Deep in the left tail, where the probabilities are tiny but still normal
+            U2 = U ÷ 3
+            @test wilcoxpdf(nx, ny, U2) ≈ Rmath.dwilcox(U2, nx, ny, false)
+            @test wilcoxcdf(nx, ny, U2) ≈ Rmath.pwilcox(U2, nx, ny, true, false)
+        end
+
+        @testset "pdf sums to one, nx = $nx, ny = $ny" for (nx, ny) in ((34, 34), (50, 50), (5, 200))
+            @test sum(wilcoxpdf(nx, ny, U) for U in 0:(nx * ny)) ≈ 1
+        end
+    end
 
     # Note: Convergence fails in srdist with cdf values below 0.16 with df = 10, k = 5.
     # Reduced df or k allows convergence. This test documents this behavior.


### PR DESCRIPTION
Fixes #219 and fixes #220.

`signrankDP` and `wilcox_partitions` accumulated combinatorial counts in `Int` and divided by the total count only at the end. Those counts grow like `2^n` and `binomial(nx + ny, nx)`, so they exceed `typemax(Int)` at moderate sample sizes: `signrankcdf` returned silently invalid probabilities from `n = 72` (#219), `wilcoxcdf` returned silently invalid probabilities from `binomial(nx + ny, nx) ≈ 3.4e18` (#220), and threw an `OverflowError` from `nx + ny = 68` (#219).

## Approach

Both recursions are linear and homogeneous, so the normaliser can be folded into the recursion rather than applied to its result. The counts are then never formed at all, and every intermediate value is a probability bounded by 1.

**`signrank`** halves at every step, `DP[i] = (DP[i] + DP[i + j]) / 2`, with a second pass over the entries whose target sum is smaller than `j` — those cannot contain `j`, so their counts are unchanged and their probabilities only pick up the factor `1/2`.

Halving is exact in binary floating point, and every count below `2^53` adds exactly, so the entries are bit-identical to the old ones divided by `2^n` while that holds, which covers `n <= 61`. Beyond that the additions round, but only barely — checked against exact `BigInt` counts:

```
n=60  max count=3.36e+15  every entry bit-identical to exact: true   max err=0.00 ulp
n=62  max count=1.28e+16  every entry bit-identical to exact: true   max err=0.50 ulp
n=70  max count=2.74e+18  every entry bit-identical to exact: false  max err=1.60 ulp
n=72  max count=1.05e+19  every entry bit-identical to exact: false  max err=2.12 ulp
```

The old implementation was valid up to `n = 71`, so in `62 <= n <= 71` results change, by at most about 1.6 ulp. For reference the old `sum(Base.Fix2(ldexp, -n) ∘ float, DP)` accumulation was itself 1.1e-15 to 1.8e-15 off at those sizes.

**`wilcox`** seeds the Löffler recurrence with `1 / binomial(nx + ny, nx)` instead of `1`, so it returns the probabilities directly. It is renamed `wilcox_probabilities` since it no longer returns partition counts. The seed is evaluated as a beta function via `logabsbinomial`, using `1 / binomial(n, k) = (n + 1) * beta(k + 1, n - k + 1)`, so it cannot overflow.

## Results

Maximum deviation from Rmath across the support:

```
n=71          max|Δcdf|=1.39e-15   max|Δpdf|=9.54e-18
n=200         max|Δcdf|=2.50e-15   max|Δpdf|=7.64e-18
nx=34 ny=34   max|Δcdf|=6.99e-15   max|Δpdf|=6.85e-17     (previously an OverflowError)
nx=150 ny=40  max|Δcdf|=1.31e-14   max|Δpdf|=1.78e-17
```

Every reproducer in the two issues:

```julia
julia> signrankcdf(72, 72 * 73 ÷ 4)   # was 0.8604874010662797
0.5011124010662795                     # Rmath: 0.5011124010662802

julia> wilcoxcdf(33, 33, 544)          # was 0.17794888610519205
0.5000000000000101                     # Rmath: 0.5000000000000029

julia> wilcoxcdf(30, 36, 540)          # was 0.7017246036833331
0.5025508900435314                     # Rmath: 0.5025508900435341

julia> wilcoxcdf(34, 34, 578)          # was OverflowError: binomial(68, 34) overflows
0.5024303008232822                     # Rmath: 0.5024303008232744

julia> sum(signrankpdf(100, w) for w in 0:5050)   # was 3.6379788070917093e-10
1.0
```

Sweeping #220's "frontier" — the first `ny` at which each `nx` disagrees with Rmath — finds no disagreement anywhere for `nx <= 34`, `ny <= 120`.

## Cost

The `wilcox` recurrence is 1.5x to 2.2x slower, growing with size (56.5 µs to 122 µs at `nx = ny = 33`): the old `Int` reduction vectorises because integer addition is associative, the `Float64` one cannot. Converting `sigmas` to `Vector{Float64}` makes no difference and `@simd` is slower, so this seems to be the price of leaving integer arithmetic. `signrank` is within 1.1x except for small `W`, where the added halving pass costs up to 1.5x.

One warning for future readers, left as a comment: deferring the `signrank` tail halvings to a single exact `ldexp` pass at the end looks 3.6x faster and is wrong, because the main loop would then add entries carrying different numbers of halvings. It returns 3.56e-01 where the answer is 8.08e-03.

## Inverse functions

`wilcoxinvcdf` was compared against `Rmath.qwilcox` at arguments that are themselves cdf values. The inverses locate a discontinuity by scanning for the first argument at which the cdf reaches `q`, so that comparison is decided by the last bit of the cdf: nudging the normaliser by a single ulp moves the result in either direction. It only passed before because the old code divided by an exactly representable `binomial`.

Rather than design the normaliser around it, `signrank` and `wilcox` are excluded from the Rmath inverse comparison, matching what #205 does for the other natively implemented discrete distributions, which round trip through their own cdf instead. Both already have such round trips in `test/rmath.jl` and they are unaffected. This also removes the existing `Sys.islinux()` special case, which was working around the same instability on one platform.

## Tests

Comparisons against Rmath at the distribution midpoint and in the left tail for `n` up to 200 and `nx + ny` up to 205, plus checks that the pdfs sum to one. The `wilcox` cases include the asymmetric ones from #220 — `(30, 36)`, `(20, 60)`, `(10, 326)` — which show that the silent threshold is set by `binomial(nx + ny, nx)` and not by `nx + ny`, since the Löffler recurrence subtracts as well as adds and its intermediates wrap before the counts do.

No compat bump is required: `logabsbinomial` is present in SpecialFunctions 1.8.1, the current lower bound.

## Scaling

The `wilcox` recurrence is O(U^2) in `U = nx * ny / 2` and `signrank` is O(n^3), both confirmed empirically (measured exponents 2.00 and 3.00). `signrank` is cheap enough to ignore, 0.14 s at `n = 1000`; `wilcox` costs 1.2 s at `nx = ny = 300` and about two minutes at `nx = ny = 1000`.

The seed `1 / binomial(nx + ny, nx)` is the probability of the least likely outcome, so it leaves the normal range long before the probabilities of interest do: subnormal from `nx + ny = 1030`, zero from `nx + ny = 1090`. Since the recurrence is homogeneous, a zero seed zeroes everything, so `wilcoxcdf` returned 0.776804 at `nx = ny = 540` and 0.0 from 545, where the answer is 0.5 by symmetry. The recurrence therefore works in units of `2^shift`, with `shift` chosen to keep the seed normal and removed from the scalar result with `ldexp`. `shift` is zero whenever the seed is already normal, so every input that worked before is bit for bit unchanged.

```
nx=ny=540   before: 0.776804   after: 0.5000389029915410   (normal approximation: 0.5000389192)
nx=ny=560   before: 0.000000   after: 0.5000368387803920   (normal approximation: 0.5000368536)
```

That moves the limit to about `nx + ny = 2050`, where the scaled values would overflow instead, and reaching it takes minutes of compute, so runtime rather than representability is now the binding constraint.

Two alternatives were measured and rejected. Switching to the normal approximation above some size is not viable: the absolute error only decays like `1/n` and the relative error is 28% at `cdf = 1e-6` even at `nx = ny = 140`, which is useless for a p-value. Switching to the Gaussian binomial product form, `prod (1 - q^(n+i)) / (1 - q^i)`, is 129x faster at `nx = ny = 400` and agrees to 1e-15 at small sizes, but it is numerically unstable: the numerator factors subtract nearly equal quantities, coefficients that must be non-negative reach -4.7e-13 by `nx = ny = 400` and -7.1e+113 by 700. It needs exact integer arithmetic, which is what we left to avoid the overflow in the first place.

One wart, noted for completeness: `ldexp` flushes the very last subnormal, so `wilcoxpdf(540, 540, 0)` is 0.0 where the exactly rounded value is 4.94e-324, the smallest representable number. That is the least likely outcome at a size whose every other value was previously garbage.
