### PR TITLE
Add `@inline` for `ForwardDiff.Dual` arguments

### DIFF
--- a/src/distrs/beta.jl
+++ b/src/distrs/beta.jl
@@ -5,8 +5,11 @@ using HypergeometricFunctions: _₂F₁
 # Julia implementations
 betapdf(α::Real, β::Real, x::Real) = exp(betalogpdf(α, β, x))
 
-betalogpdf(α::Real, β::Real, x::Real) = betalogpdf(promote(α, β, x)...)
-function betalogpdf(α::T, β::T, x::T) where {T <: Real}
+# `@inline` for `ForwardDiff.Dual` arguments, and so that callers such as
+# `binomlogpdf` and `betapdf` inline it into their bodies (#223). Both methods need
+# it, otherwise the un-annotated wrapper becomes the inlining barrier instead.
+@inline betalogpdf(α::Real, β::Real, x::Real) = betalogpdf(promote(α, β, x)...)
+@inline function betalogpdf(α::T, β::T, x::T) where {T <: Real}
     # we ensure that `log(x)` and `log1p(-x)` do not error
     y = clamp(x, 0, 1)
     val = xlogy(α - 1, y) + xlog1py(β - 1, -y) - logbeta(α, β)

--- a/src/distrs/gamma.jl
+++ b/src/distrs/gamma.jl
@@ -5,8 +5,11 @@ using HypergeometricFunctions: _₁F₁
 # Julia implementations
 gammapdf(k::Real, θ::Real, x::Real) = exp(gammalogpdf(k, θ, x))
 
-gammalogpdf(k::Real, θ::Real, x::Real) = gammalogpdf(promote(k, θ, x)...)
-function gammalogpdf(k::T, θ::T, x::T) where {T <: Real}
+# `@inline` for `ForwardDiff.Dual` arguments, and so that callers such as
+# `chisqlogpdf` inline it into their bodies (#223). Both methods need it,
+# otherwise the un-annotated wrapper becomes the inlining barrier instead.
+@inline gammalogpdf(k::Real, θ::Real, x::Real) = gammalogpdf(promote(k, θ, x)...)
+@inline function gammalogpdf(k::T, θ::T, x::T) where {T <: Real}
     # we ensure that `log(x)` does not error if `x < 0`
     xθ = max(x, 0) / θ
     val = -loggamma(k) - log(θ) - xθ

--- a/src/distrs/norm.jl
+++ b/src/distrs/norm.jl
@@ -1,5 +1,9 @@
 # functions related to normal distribution
 
+# The `@inline` annotations below are needed for `ForwardDiff.Dual` arguments: the
+# expansion of `exp`/`erfc`/`log` pushes these bodies over the inlining cost
+# threshold, so without them the functions are not inlined at their call sites (#223)
+
 function xval(μ::Real, σ::Real, z::Number)
     return if isinf(z) && iszero(σ)
         μ + one(σ) * z
@@ -10,8 +14,8 @@ end
 zval(μ::Real, σ::Real, x::Number) = (x - μ) / σ
 
 # pdf
-normpdf(z::Number) = exp(-abs2(z) / 2) * invsqrt2π
-function normpdf(μ::Real, σ::Real, x::Number)
+@inline normpdf(z::Number) = exp(-abs2(z) / 2) * invsqrt2π
+@inline function normpdf(μ::Real, σ::Real, x::Number)
     if iszero(σ)
         if x == μ
             z = zval(μ, one(σ), x)
@@ -26,8 +30,8 @@ function normpdf(μ::Real, σ::Real, x::Number)
 end
 
 # logpdf
-normlogpdf(z::Number) = -(abs2(z) + log2π) / 2
-function normlogpdf(μ::Real, σ::Real, x::Number)
+@inline normlogpdf(z::Number) = -(abs2(z) + log2π) / 2
+@inline function normlogpdf(μ::Real, σ::Real, x::Number)
     if iszero(σ)
         if x == μ
             z = zval(μ, one(σ), x)
@@ -42,8 +46,8 @@ function normlogpdf(μ::Real, σ::Real, x::Number)
 end
 
 # cdf
-normcdf(z::Number) = erfc(-z * invsqrt2) / 2
-function normcdf(μ::Real, σ::Real, x::Number)
+@inline normcdf(z::Number) = erfc(-z * invsqrt2) / 2
+@inline function normcdf(μ::Real, σ::Real, x::Number)
     if iszero(σ) && x == μ
         z = zval(zero(μ), σ, one(x))
     else
@@ -52,8 +56,8 @@ function normcdf(μ::Real, σ::Real, x::Number)
     return normcdf(z)
 end
 # ccdf
-normccdf(z::Number) = erfc(z * invsqrt2) / 2
-function normccdf(μ::Real, σ::Real, x::Number)
+@inline normccdf(z::Number) = erfc(z * invsqrt2) / 2
+@inline function normccdf(μ::Real, σ::Real, x::Number)
     if iszero(σ) && x == μ
         z = zval(zero(μ), σ, one(x))
     else
@@ -63,10 +67,10 @@ function normccdf(μ::Real, σ::Real, x::Number)
 end
 
 # logcdf
-normlogcdf(z::Number) = z < -1.0 ?
+@inline normlogcdf(z::Number) = z < -1.0 ?
     log(erfcx(-z * invsqrt2) / 2) - abs2(z) / 2 :
     log1p(-erfc(z * invsqrt2) / 2)
-function normlogcdf(μ::Real, σ::Real, x::Number)
+@inline function normlogcdf(μ::Real, σ::Real, x::Number)
     if iszero(σ) && x == μ
         z = zval(zero(μ), σ, one(x))
     else
@@ -76,10 +80,10 @@ function normlogcdf(μ::Real, σ::Real, x::Number)
 end
 
 # logccdf
-normlogccdf(z::Number) = z > 1.0 ?
+@inline normlogccdf(z::Number) = z > 1.0 ?
     log(erfcx(z * invsqrt2) / 2) - abs2(z) / 2 :
     log1p(-erfc(-z * invsqrt2) / 2)
-function normlogccdf(μ::Real, σ::Real, x::Number)
+@inline function normlogccdf(μ::Real, σ::Real, x::Number)
     if iszero(σ) && x == μ
         z = zval(zero(μ), σ, one(x))
     else

--- a/test/inlining.jl
+++ b/test/inlining.jl
@@ -1,0 +1,68 @@
+using StatsFuns
+using ForwardDiff: Dual
+using Test
+
+# `normpdf` and `normlogpdf` carry `@inline` (#223). Without it they are not
+# inlined for `ForwardDiff.Dual` arguments, and a loop calling them costs
+# noticeably more than a loop calling `log` on a `Dual`. Measuring against that
+# baseline instead of against absolute times keeps the bounds independent of the
+# machine the tests run on.
+#
+# Only these two functions are checked: for the other functions annotated in
+# #223 the difference between the inlined and the non-inlined version is a
+# factor 1.04-1.33, which is too small to assert on shared CI runners.
+
+function accumulate_f(f, μ, σ, xs)
+    s = zero(μ)
+    for x in xs
+        s += f(μ, σ, x)
+    end
+    return s
+end
+
+function accumulate_log(μ, _, xs)
+    s = zero(μ)
+    for x in xs
+        s += log(μ + x)
+    end
+    return s
+end
+
+function mintime(f, args...)
+    t = typemax(UInt64)
+    for _ in 1:50
+        t0 = time_ns()
+        f(args...)
+        t = min(t, time_ns() - t0)
+    end
+    return t
+end
+
+@testset "Inlining for Dual arguments" begin
+    μ = Dual{:StatsFunsInlining}(0.1, 1.0, 0.0, 0.0, 0.0)
+    σ = 1.3
+    xs = collect(range(4.0, 9.0; length = 4096))  # positive, so `log` stays in domain
+
+    bounds = ((normpdf, 2.0), (normlogpdf, 1.4))
+
+    # compile everything before timing anything
+    accumulate_log(μ, σ, xs)
+    for (f, _) in bounds
+        accumulate_f(f, μ, σ, xs)
+    end
+
+    # interleave baseline and target measurements so that a load spike during one
+    # of them cannot skew the ratio in only one direction
+    baseline = typemax(UInt64)
+    times = Dict{Any, UInt64}(f => typemax(UInt64) for (f, _) in bounds)
+    for _ in 1:2
+        baseline = min(baseline, mintime(accumulate_log, μ, σ, xs))
+        for (f, _) in bounds
+            times[f] = min(times[f], mintime(accumulate_f, f, μ, σ, xs))
+        end
+    end
+
+    @testset "$f" for (f, bound) in bounds
+        @test times[f] / baseline < bound
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
-tests = ["owens_t", "rmath", "generic", "misc", "chainrules", "inverse", "tvpack", "qa"]
+tests = ["owens_t", "rmath", "generic", "misc", "chainrules", "inverse", "inlining", "tvpack", "qa"]
 
 for t in tests
     fp = "$t.jl"


### PR DESCRIPTION
Fixes #223.

`@inline` on the six functions in `norm.jl` (both the `z`-form and the 3-arg form), on `betalogpdf` and on `gammalogpdf`. Without it these are not inlined for `ForwardDiff.Dual` arguments, although they are for `Float64`.

Relative cost of a loop over a varying `Float64` `x` with `Dual` parameters, normalised by a loop calling the special function that dominates the body, medians over 4 runs of master and 2 of this branch, same at `-O2` and `-O3`:

| | master | this PR | |
|---|---|---|---|
| `normpdf` | 3.43 | 1.73 | -50% |
| `normlogpdf` | 2.06 | 1.50 | -27% |
| `gammalogpdf` | 2.32 | 1.68 | -27% |
| `chisqlogpdf` | 2.34 | 1.79 | -24% |
| `binomlogpdf` | 6.68 | 5.15 | -23% |
| `binompdf` | 6.63 | 5.35 | -19% |
| `normlogcdf` | 0.95 | 0.77 | -18% |
| `normlogccdf` | 0.98 | 0.80 | -18% |
| `normcdf` | 0.79 | 0.66 | -17% |
| `normccdf` | 0.78 | 0.66 | -16% |
| `betapdf` | 4.66 | 4.07 | -13% |
| `betalogpdf` | 3.90 | 3.65 | -6% |

`chisqlogpdf`, `binomlogpdf`, `binompdf` and `betapdf` are not annotated themselves and improve because `gammalogpdf` and `betalogpdf` are inlined into their bodies, so their own call sites do not grow. Everything else is within ±8% and nothing regresses. Values are unchanged.

`fdistlogpdf`, `tdistlogpdf` and `poislogpdf` are deliberately left alone. See #223 for the numbers: annotating them costs 361-926 LLVM lines per call site for -10% to -12%, and for `poislogpdf` it gains nothing at all while costing `poispdf` about 12%. Annotating `binomlogpdf` on top of `betalogpdf` would take it from -23% to -31%, for 926 LLVM lines per call site instead of 20, which does not look worth it.

`test/inlining.jl` asserts the relative cost for `normpdf` and `normlogpdf`. Those are the two functions where the inlined and non-inlined versions are far enough apart to assert on: in the test's own loop the ratio to the baseline goes from 4.15 to 1.15 and from 1.91 to 1.08, against bounds of 2.0 and 1.4. For the remaining annotated functions the separation is only a factor 1.04-1.33, which is too small to bound reliably on shared CI runners. Removing the annotations from `norm.jl` makes both assertions fail.

(This PR was written with the assistance of generative AI.)
